### PR TITLE
fix: get region by read lock

### DIFF
--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -161,6 +161,8 @@ public:
 private:
     RegionPtr loadRegionByKey(Backoffer & bo, const std::string & key);
 
+    RegionPtr getRegionByIDFromCache(const RegionVerID & region_id);
+
     RegionPtr loadRegionByID(Backoffer & bo, uint64_t region_id);
 
     metapb::Store loadStore(Backoffer & bo, uint64_t id);


### PR DESCRIPTION
Signed-off-by: Han Fei <hanfei19910905@gmail.com>

Should operate `regions` map by lock guard.