### PR TITLE
fix memory leak

### DIFF
--- a/include/pingcap/kv/internal/type_traits.h
+++ b/include/pingcap/kv/internal/type_traits.h
@@ -3,38 +3,33 @@
 #include <kvproto/metapb.pb.h>
 #include <kvproto/tikvpb.grpc.pb.h>
 
-namespace pingcap
-{
-namespace kv
-{
+namespace pingcap {
+namespace kv {
 
-// create and destroy stub but not destroy channel may case memory leak, so we bound channel and stub in same struct.
+// create and destroy stub but not destroy channel may case memory leak, so we
+// bound channel and stub in same struct.
 struct KvConnClient {
-    std::shared_ptr<grpc::Channel> channel;
-    std::unique_ptr<tikvpb::Tikv::Stub> stub;
-    KvConnClient(std::string addr) {
-        channel = grpc::CreateChannel(addr, grpc::InsecureChannelCredentials());
-        stub = tikvpb::Tikv::NewStub(channel);
-    }
+  std::shared_ptr<grpc::Channel> channel;
+  std::unique_ptr<tikvpb::Tikv::Stub> stub;
+  KvConnClient(std::string addr) {
+    channel = grpc::CreateChannel(addr, grpc::InsecureChannelCredentials());
+    stub = tikvpb::Tikv::NewStub(channel);
+  }
 };
 
-template <class T>
-struct RpcTypeTraits
-{
-};
+template <class T> struct RpcTypeTraits {};
 
-#define PINGCAP_DEFINE_TRAITS(NAME, METHOD) \
-template<> struct RpcTypeTraits<::kvrpcpb::NAME##Request> \
-{ \
-    using RequestType = ::kvrpcpb::NAME##Request; \
-    using ResultType = ::kvrpcpb::NAME##Response; \
-    static const char * err_msg() { return #NAME" Failed"; } \
-    static ::grpc::Status doRPCCall( \
-        grpc::ClientContext * context, std::shared_ptr<KvConnClient> client, const RequestType & req, ResultType * res) \
-    {\
-        return client->stub->METHOD(context, req, res); \
-    }\
-};
+#define PINGCAP_DEFINE_TRAITS(NAME, METHOD)                                    \
+  template <> struct RpcTypeTraits<::kvrpcpb::NAME##Request> {                 \
+    using RequestType = ::kvrpcpb::NAME##Request;                              \
+    using ResultType = ::kvrpcpb::NAME##Response;                              \
+    static const char *err_msg() { return #NAME " Failed"; }                   \
+    static ::grpc::Status doRPCCall(grpc::ClientContext *context,              \
+                                    std::shared_ptr<KvConnClient> client,      \
+                                    const RequestType &req, ResultType *res) { \
+      return client->stub->METHOD(context, req, res);                          \
+    }                                                                          \
+  };
 
 PINGCAP_DEFINE_TRAITS(SplitRegion, SplitRegion)
 PINGCAP_DEFINE_TRAITS(Commit, KvCommit)

--- a/src/kv/Rpc.cc
+++ b/src/kv/Rpc.cc
@@ -10,11 +10,11 @@ ConnArray::ConnArray(size_t max_size, std::string addr) : address(addr), index(0
     vec.resize(max_size);
     for (size_t i = 0; i < max_size; i++)
     {
-        vec[i] = grpc::CreateChannel(addr, grpc::InsecureChannelCredentials());
+        vec[i] = std::make_shared<KvConnClient>(addr);
     }
 }
 
-std::shared_ptr<grpc::Channel> ConnArray::get()
+std::shared_ptr<KvConnClient> ConnArray::get()
 {
     std::lock_guard<std::mutex> lock(mutex);
     index = (index + 1) % vec.size();


### PR DESCRIPTION
as https://groups.google.com/forum/#!topic/grpc-io/7pd2kqAstdY described, If you create and destroy a stub but remain the channel, there will cause memory leak.
As a work around method, we bound every channel and stub together, so they can share same life cycle.