### PR TITLE
Support fallback resolve lock for async commit to resolve lock for sync commit

### DIFF
--- a/include/pingcap/Exception.h
+++ b/include/pingcap/Exception.h
@@ -26,7 +26,8 @@ enum ErrorCodes : int
     RegionEpochNotMatch = 14,
     CoprocessorError = 15,
     TxnNotFound = 16,
-    UnknownError = 17
+    NonAsyncCommit = 17,
+    UnknownError = 18
 };
 
 class Exception : public Poco::Exception

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -159,6 +159,11 @@ struct AsyncResolveData
                     ErrorCodes::UnknownError);
             }
 
+            if (!lock.use_async_commit())
+            {
+                throw Exception("CheckSecondaryLocks receives a non-async-commit lock", ErrorCodes::NonAsyncCommit);
+            }
+
             if (!missing_lock && lock.min_commit_ts() > commit_ts)
             {
                 commit_ts = lock.min_commit_ts();
@@ -239,11 +244,11 @@ private:
         Backoffer & bo, uint64_t txn_id, std::vector<std::string> & cur_keys, RegionVerID cur_region_id, AsyncResolveDataPtr shared_data);
 
 
-    TxnStatus getTxnStatusFromLock(Backoffer & bo, LockPtr lock, uint64_t caller_start_ts);
+    TxnStatus getTxnStatusFromLock(Backoffer & bo, LockPtr lock, uint64_t caller_start_ts, bool force_sync_commit);
 
 
     TxnStatus getTxnStatus(Backoffer & bo, uint64_t txn_id, const std::string & primary, uint64_t caller_start_ts, uint64_t current_ts,
-        bool rollback_if_not_exists);
+        bool rollback_if_not_exists, bool force_sync_commit);
 
     Cluster * cluster;
     std::shared_mutex mu;


### PR DESCRIPTION
For concern about performance, if prewrite of async commit transaction takes too long, the transaction will fallback to sync commit.

In this case, there exists some secondary keys prewritten with `use_async_commit` flag, while the rest are prewritten in sync way. To resolve locks of transactions like this, we should fallback to `resolveLock` instead of  `resolveLockAsync` when we meet locks with `use_async_commit` flag.

Reference: https://github.com/tikv/sig-transaction/issues/64#issuecomment-738530608