### PR TITLE
Changes to support Mpp mock test in TiFlash

### DIFF
--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -26,7 +26,7 @@ struct Cluster
 
     LockResolverPtr lock_resolver;
 
-    Cluster() : pd_client(std::make_shared<pd::MockPDClient>()) {}
+    Cluster() : pd_client(std::make_shared<pd::MockPDClient>()), rpc_client(std::make_unique<RpcClient>()) {}
 
     Cluster(const std::vector<std::string> & pd_addrs, const ClusterConfig & config)
         : pd_client(std::make_shared<pd::CodecClient>(pd_addrs, config)),

--- a/include/pingcap/kv/internal/type_traits.h
+++ b/include/pingcap/kv/internal/type_traits.h
@@ -41,6 +41,7 @@ PINGCAP_DEFINE_TRAITS(kvrpcpb, PessimisticRollback, KVPessimisticRollback)
 PINGCAP_DEFINE_TRAITS(kvrpcpb, TxnHeartBeat, KvTxnHeartBeat)
 PINGCAP_DEFINE_TRAITS(kvrpcpb, CheckSecondaryLocks, KvCheckSecondaryLocks)
 PINGCAP_DEFINE_TRAITS(coprocessor, , Coprocessor)
+PINGCAP_DEFINE_TRAITS(mpp, DispatchTask, DispatchMPPTask)
 
 
 } // namespace kv


### PR DESCRIPTION
This pr contains two minor changes to support mpp mock test in TiFlash
1. create `rpc_client` in mock mode
2. support `DispatchMPPTask` rpc