### PR TITLE
Drop region if store state is Tombstone

### DIFF
--- a/src/kv/RegionClient.cc
+++ b/src/kv/RegionClient.cc
@@ -28,6 +28,7 @@ void RegionClient::onRegionError(Backoffer & bo, RPCContextPtr rpc_ctx, const er
     if (err.has_store_not_match())
     {
         cluster->region_cache->dropStore(rpc_ctx->peer.store_id());
+        cluster->region_cache->dropRegion(rpc_ctx->region);
         return;
     }
 


### PR DESCRIPTION
The root cause is if a store is removed from cluster and then another new store takes its place(IP, port), client-c cannot update store information.

See https://github.com/pingcap/tidb/pull/22909