### PR TITLE
Fix clang-tidy lint

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,211 @@
+Checks: '-*,
+    misc-throw-by-value-catch-by-reference,
+    misc-misplaced-const,
+    misc-unconventional-assign-operator,
+    misc-redundant-expression,
+    misc-static-assert,
+    misc-unconventional-assign-operator,
+    misc-uniqueptr-reset-release,
+    misc-unused-alias-decls,
+    misc-unused-parameters,
+    misc-unused-using-decls,
+
+    modernize-avoid-bind,
+    modernize-loop-convert,
+    modernize-make-shared,
+    modernize-make-unique,
+    modernize-raw-string-literal,
+    modernize-redundant-void-arg,
+    modernize-replace-auto-ptr,
+    modernize-replace-random-shuffle,
+    modernize-use-auto,
+    modernize-use-bool-literals,
+    modernize-use-nullptr,
+    modernize-use-using,
+    modernize-use-override,
+    modernize-use-equals-default,
+    modernize-use-equals-delete,
+
+    performance-faster-string-find,
+    performance-for-range-copy,
+    performance-implicit-conversion-in-loop,
+    performance-inefficient-algorithm,
+    performance-inefficient-vector-operation,
+    performance-move-constructor-init,
+    performance-no-automatic-move,
+    performance-trivially-destructible,
+    performance-unnecessary-copy-initialization,
+
+    readability-avoid-const-params-in-decls,
+    readability-const-return-type,
+    readability-container-size-empty,
+    readability-convert-member-functions-to-static,
+    readability-delete-null-pointer,
+    readability-deleted-default,
+    readability-make-member-function-const,
+    readability-misplaced-array-index,
+    readability-non-const-parameter,
+    readability-qualified-auto,
+    readability-redundant-control-flow,
+    readability-redundant-function-ptr-dereference,
+    readability-redundant-smartptr-get,
+    readability-redundant-string-cstr,
+    readability-redundant-string-init,
+    readability-static-definition-in-anonymous-namespace,
+    readability-string-compare,
+    readability-uniqueptr-delete-release,
+    readability-redundant-member-init,
+    readability-simplify-subscript-expr,
+    readability-simplify-boolean-expr,
+    readability-inconsistent-declaration-parameter-name,
+    readability-identifier-naming,
+
+    bugprone-undelegated-constructor,
+    bugprone-argument-comment,
+    bugprone-bad-signal-to-kill-thread,
+    bugprone-bool-pointer-implicit-conversion,
+    bugprone-copy-constructor-init,
+    bugprone-dangling-handle,
+    bugprone-forward-declaration-namespace,
+    bugprone-fold-init-type,
+    bugprone-inaccurate-erase,
+    bugprone-incorrect-roundings,
+    bugprone-infinite-loop,
+    bugprone-integer-division,
+    bugprone-macro-parentheses,
+    bugprone-macro-repeated-side-effects,
+    bugprone-misplaced-operator-in-strlen-in-alloc,
+    bugprone-misplaced-pointer-artithmetic-in-alloc,
+    bugprone-misplaced-widening-cast,
+    bugprone-move-forwarding-reference,
+    bugprone-multiple-statement-macro,
+    bugprone-parent-virtual-call,
+    bugprone-posix-return,
+    bugprone-reserved-identifier,
+    bugprone-signed-char-misuse,
+    bugprone-sizeof-container,
+    bugprone-sizeof-expression,
+    bugprone-string-constructor,
+    bugprone-string-integer-assignment,
+    bugprone-string-literal-with-embedded-nul,
+    bugprone-suspicious-enum-usage,
+    bugprone-suspicious-include,
+    bugprone-suspicious-memset-usage,
+    bugprone-suspicious-missing-comma,
+    bugprone-suspicious-string-compare,
+    bugprone-swapped-arguments,
+    bugprone-terminating-continue,
+    bugprone-throw-keyword-missing,
+    bugprone-too-small-loop-variable,
+    bugprone-undefined-memory-manipulation,
+    bugprone-unhandled-self-assignment,
+    bugprone-unused-raii,
+    bugprone-unused-return-value,
+    bugprone-use-after-move,
+    bugprone-virtual-near-miss,
+
+    cert-dcl21-cpp,
+    cert-dcl50-cpp,
+    cert-env33-c,
+    cert-err34-c,
+    cert-err52-cpp,
+    cert-flp30-c,
+    cert-mem57-cpp,
+    cert-msc50-cpp,
+    cert-oop58-cpp,
+
+    google-build-explicit-make-pair,
+    google-build-namespaces,
+    google-default-arguments,
+    google-explicit-constructor,
+    google-readability-casting,
+    google-readability-avoid-underscore-in-googletest-name,
+    google-runtime-int,
+    google-runtime-operator,
+
+    hicpp-exception-baseclass,
+
+    clang-analyzer-core.CallAndMessage,
+    clang-analyzer-core.DivideZero,
+    clang-analyzer-core.NonNullParamChecker,
+    clang-analyzer-core.NullDereference,
+    clang-analyzer-core.StackAddressEscape,
+    clang-analyzer-core.UndefinedBinaryOperatorResult,
+    clang-analyzer-core.VLASize,
+    clang-analyzer-core.uninitialized.ArraySubscript,
+    clang-analyzer-core.uninitialized.Assign,
+    clang-analyzer-core.uninitialized.Branch,
+    clang-analyzer-core.uninitialized.CapturedBlockVariable,
+    clang-analyzer-core.uninitialized.UndefReturn,
+    clang-analyzer-cplusplus.InnerPointer,
+    clang-analyzer-cplusplus.NewDelete,
+    clang-analyzer-cplusplus.NewDeleteLeaks,
+    clang-analyzer-cplusplus.PlacementNewChecker,
+    clang-analyzer-cplusplus.SelfAssignment,
+    clang-analyzer-deadcode.DeadStores,
+    clang-analyzer-optin.cplusplus.VirtualCall,
+    clang-analyzer-security.insecureAPI.UncheckedReturn,
+    clang-analyzer-security.insecureAPI.bcmp,
+    clang-analyzer-security.insecureAPI.bcopy,
+    clang-analyzer-security.insecureAPI.bzero,
+    clang-analyzer-security.insecureAPI.getpw,
+    clang-analyzer-security.insecureAPI.gets,
+    clang-analyzer-security.insecureAPI.mkstemp,
+    clang-analyzer-security.insecureAPI.mktemp,
+    clang-analyzer-security.insecureAPI.rand,
+    clang-analyzer-security.insecureAPI.strcpy,
+    clang-analyzer-unix.Malloc,
+    clang-analyzer-unix.MallocSizeof,
+    clang-analyzer-unix.MismatchedDeallocator,
+    clang-analyzer-unix.Vfork,
+    clang-analyzer-unix.cstring.BadSizeArg,
+    clang-analyzer-unix.cstring.NullArg,
+
+    boost-use-to-string,
+    
+    cppcoreguidelines-pro-type-cstyle-cast,
+    cppcoreguidelines-pro-type-member-init,
+    cppcoreguidelines-no-malloc,
+    cppcoreguidelines-virtual-class-destructor,
+'
+WarningsAsErrors: '*'
+
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.LocalVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.StaticConstantCase
+    value: aNy_CasE
+  - key: readability-identifier-naming.MemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: ''
+  - key: readability-identifier-naming.ProtectedMemberPrefix
+    value: ''
+  - key: readability-identifier-naming.PublicMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.MethodCase
+    value: camelBack
+  - key: readability-identifier-naming.PrivateMethodPrefix
+    value: ''
+  - key: readability-identifier-naming.ProtectedMethodPrefix
+    value: ''
+  - key: readability-identifier-naming.ParameterPackCase
+    value: lower_case
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.TemplateTemplateParameterCase
+    value: CamelCase
+  - key: readability-identifier-naming.TemplateUsingCase
+    value: lower_case
+  - key: readability-identifier-naming.TypeTemplateParameterCase
+    value: CamelCase
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key: readability-identifier-naming.UnionCase
+    value: CamelCase
+  - key: readability-identifier-naming.UsingCase
+    value: CamelCase

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ cmake-build*
 tags
 .clang-format
 .vscode
+
+# vscode clangd cache
+.cache

--- a/include/pingcap/Config.h
+++ b/include/pingcap/Config.h
@@ -7,7 +7,6 @@
 
 namespace pingcap
 {
-
 struct ClusterConfig
 {
     std::string tiflash_engine_key;
@@ -16,7 +15,7 @@ struct ClusterConfig
     std::string cert_path;
     std::string key_path;
 
-    ClusterConfig() {}
+    ClusterConfig() = default;
 
     ClusterConfig(const std::string & engine_key_, const std::string & engine_value_, const std::string & ca_path_, const std::string & cert_path_, const std::string & key_path_)
         : tiflash_engine_key(engine_key_)
@@ -43,7 +42,7 @@ struct ClusterConfig
     }
 
 private:
-    std::string readFile(const std::string & path) const
+    static std::string readFile(const std::string & path)
     {
         std::ifstream t(path.data());
         std::string str((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());

--- a/include/pingcap/Exception.h
+++ b/include/pingcap/Exception.h
@@ -7,7 +7,6 @@
 
 namespace pingcap
 {
-
 enum ErrorCodes : int
 {
     MismatchClusterIDCode = 1,
@@ -33,8 +32,8 @@ enum ErrorCodes : int
 class Exception : public Poco::Exception
 {
 public:
-    Exception() {} /// For deferred initialization.
-    Exception(const std::string & msg, int code = 0)
+    Exception() = default; /// For deferred initialization.
+    explicit Exception(const std::string & msg, int code = 0)
         : Poco::Exception(msg, code)
     {}
     Exception(const std::string & msg, const std::string & arg, int code = 0)

--- a/include/pingcap/RedactHelpers.h
+++ b/include/pingcap/RedactHelpers.h
@@ -5,7 +5,6 @@
 
 namespace pingcap
 {
-
 class Redact
 {
 public:
@@ -18,7 +17,7 @@ public:
     static std::string keyToHexString(const char * key, size_t size);
 
 protected:
-    Redact() {}
+    Redact() = default;
 
 private:
     // Log user data to log only when this flag is set to false.

--- a/include/pingcap/SetThreadName.h
+++ b/include/pingcap/SetThreadName.h
@@ -18,7 +18,7 @@ namespace pingcap
 {
 inline void SetThreadName(const char * tname)
 {
-    constexpr auto MAX_LEN = 15; // thread name will be tname[:MAX_LEN]
+    constexpr static auto MAX_LEN = 15; // thread name will be tname[:MAX_LEN]
     if (std::strlen(tname) > MAX_LEN)
         std::cerr << "set thread name " << tname << " is too long and will be truncated by system\n";
 

--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -12,7 +12,6 @@ namespace pingcap
 {
 namespace coprocessor
 {
-
 enum ReqType : int16_t
 {
     Select = 101,
@@ -68,21 +67,22 @@ public:
         std::shared_ptr<::coprocessor::Response> resp;
         Exception error;
 
-        Result() {}
-        Result(std::shared_ptr<::coprocessor::Response> resp_)
+        Result() = default;
+        explicit Result(std::shared_ptr<::coprocessor::Response> resp_)
             : resp(resp_)
         {}
-        Result(const Exception & err)
+        explicit Result(const Exception & err)
             : error(err)
         {}
 
-        const std::string & data() { return resp->data(); }
+        const std::string & data() const { return resp->data(); }
     };
 
     ResponseIter(std::vector<copTask> && tasks_, kv::Cluster * cluster_, int concurrency_, Logger * log_)
         : tasks(std::move(tasks_))
         , cluster(cluster_)
         , concurrency(concurrency_)
+        , unfinished_thread(0)
         , cancelled(false)
         , log(log_)
     {}
@@ -90,9 +90,9 @@ public:
     ~ResponseIter()
     {
         cancelled = true;
-        for (auto it = worker_threads.begin(); it != worker_threads.end(); it++)
+        for (auto & worker_thread : worker_threads)
         {
-            it->join();
+            worker_thread.join();
         }
     }
 
@@ -117,12 +117,12 @@ public:
     std::pair<Result, bool> next()
     {
         std::unique_lock<std::mutex> lk(results_mutex);
-        cond_var.wait(lk, [this] { return unfinished_thread == 0 || cancelled || results.size() > 0; });
+        cond_var.wait(lk, [this] { return unfinished_thread == 0 || cancelled || !results.empty(); });
         if (cancelled)
         {
             return std::make_pair(Result(), false);
         }
-        if (results.size() > 0)
+        if (!results.empty())
         {
             auto ret = std::make_pair(results.front(), true);
             results.pop();

--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -158,12 +158,12 @@ private:
             const copTask & task = tasks[task_index];
             task_index++;
             lk.unlock();
-            handle_task(task);
+            handleTask(task);
         }
     }
 
-    std::vector<copTask> handle_task_impl(kv::Backoffer & bo, const copTask & task);
-    void handle_task(const copTask & task);
+    std::vector<copTask> handleTaskImpl(kv::Backoffer & bo, const copTask & task);
+    void handleTask(const copTask & task);
 
     size_t task_index = 0;
     std::vector<copTask> tasks;

--- a/include/pingcap/kv/2pc.h
+++ b/include/pingcap/kv/2pc.h
@@ -118,7 +118,7 @@ private:
     friend class TestTwoPhaseCommitter;
 
 public:
-    TwoPhaseCommitter(Txn * txn, bool _use_async_commit = false);
+    explicit TwoPhaseCommitter(Txn * txn, bool _use_async_commit = false);
 
     void execute();
 

--- a/include/pingcap/kv/Backoff.h
+++ b/include/pingcap/kv/Backoff.h
@@ -12,7 +12,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 enum Jitter
 {
     NoJitter = 1,
@@ -110,7 +109,7 @@ struct Backoffer
     size_t total_sleep; // ms
     size_t max_sleep; // ms
 
-    Backoffer(size_t max_sleep_)
+    explicit Backoffer(size_t max_sleep_)
         : total_sleep(0)
         , max_sleep(max_sleep_)
     {}

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -56,13 +56,13 @@ struct MinCommitTSPushed
 
     MinCommitTSPushed(MinCommitTSPushed &) {}
 
-    inline void add_timestamps(std::vector<uint64_t> & tss)
+    inline void addTimestamps(std::vector<uint64_t> & tss)
     {
         std::lock_guard guard{mutex};
         container.insert(tss.begin(), tss.end());
     }
 
-    inline std::vector<uint64_t> get_timestamps() const
+    inline std::vector<uint64_t> getTimestamps() const
     {
         std::lock_guard guard{mutex};
         std::vector<uint64_t> result;

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -12,7 +12,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 constexpr int oracle_update_interval = 2000;
 // Cluster represents a tikv+pd cluster.
 
@@ -41,7 +40,7 @@ struct Cluster
 
     // TODO: When the cluster is closed, we should release all the resources
     // (e.g. background threads) that cluster object holds so as to exit elegantly.
-    ~Cluster() {}
+    ~Cluster() = default;
 
     // Only used by Test and this is not safe !
     void splitRegion(const std::string & split_key);
@@ -51,11 +50,11 @@ struct MinCommitTSPushed
 {
     std::unordered_set<uint64_t> container;
 
-    std::mutex mutex;
+    mutable std::mutex mutex;
 
-    MinCommitTSPushed(){};
+    MinCommitTSPushed() = default;
 
-    MinCommitTSPushed(MinCommitTSPushed &){};
+    MinCommitTSPushed(MinCommitTSPushed &) {}
 
     inline void add_timestamps(std::vector<uint64_t> & tss)
     {
@@ -63,7 +62,7 @@ struct MinCommitTSPushed
         container.insert(tss.begin(), tss.end());
     }
 
-    inline std::vector<uint64_t> get_timestamps()
+    inline std::vector<uint64_t> get_timestamps() const
     {
         std::lock_guard guard{mutex};
         std::vector<uint64_t> result;

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -13,7 +13,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 struct Cluster;
 
 // TxnStatus represents a txn's final status. It should be Lock or Commit or Rollback.
@@ -23,9 +22,9 @@ struct TxnStatus
     uint64_t commit_ts = 0;
     ::kvrpcpb::Action action;
     std::optional<::kvrpcpb::LockInfo> primary_lock;
-    bool isCommitted() { return ttl == 0 && commit_ts > 0; }
+    bool isCommitted() const { return ttl == 0 && commit_ts > 0; }
 
-    bool isCacheable()
+    bool isCacheable() const
     {
         if (isCommitted())
         {
@@ -65,7 +64,7 @@ struct Lock
     uint64_t lock_for_update_ts;
     uint64_t min_commit_ts;
 
-    Lock(const ::kvrpcpb::LockInfo & l)
+    explicit Lock(const ::kvrpcpb::LockInfo & l)
         : key(l.key())
         , primary(l.primary_lock())
         , txn_id(l.lock_version())
@@ -114,7 +113,7 @@ struct TxnExpireTime
             txn_expire = lock_expire;
     }
 
-    int64_t value() { return initialized ? txn_expire : 0; }
+    int64_t value() const { return initialized ? txn_expire : 0; }
 };
 
 // AsyncResolveData is data contributed by multiple threads when resolving locks using the async commit protocol. All
@@ -174,7 +173,7 @@ struct AsyncResolveData
 
         for (int i = 0; i < resp->locks_size(); i++)
         {
-            auto & lock = resp->locks(i);
+            const auto & lock = resp->locks(i);
             if (lock.lock_version() != start_ts)
             {
                 throw Exception(
@@ -202,7 +201,7 @@ using AsyncResolveDataPtr = std::shared_ptr<AsyncResolveData>;
 class LockResolver
 {
 public:
-    LockResolver(Cluster * cluster_)
+    explicit LockResolver(Cluster * cluster_)
         : cluster(cluster_)
         , log(&Logger::get("pingcap/resolve_lock"))
     {}

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -206,7 +206,7 @@ public:
         , log(&Logger::get("pingcap/resolve_lock"))
     {}
 
-    // ResolveLocks tries to resolve Locks. The resolving process is in 3 steps:
+    // resolveLocks tries to resolve Locks. The resolving process is in 3 steps:
     // 1) Use the `lockTTL` to pick up all expired locks. Only locks that are too
     //    old are considered orphan locks and will be handled later. If all locks
     //    are expired then all locks will be resolved so the returned `ok` will be
@@ -216,7 +216,7 @@ public:
     // 3) Send `ResolveLock` cmd to the lock's region to resolve all locks belong to
     //    the same transaction.
 
-    int64_t ResolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed);
+    int64_t resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed);
 
     int64_t resolveLocks(
         Backoffer & bo,

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -9,7 +9,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 constexpr int dailTimeout = 5;
 constexpr int copTimeout = 20;
 
@@ -77,10 +76,10 @@ struct RegionClient
     }
 
 protected:
-    void onRegionError(Backoffer & bo, RPCContextPtr rpc_ctx, const errorpb::Error & err);
+    void onRegionError(Backoffer & bo, RPCContextPtr rpc_ctx, const errorpb::Error & err) const;
 
     // Normally, it happens when machine down or network partition between tidb and kv or process crash.
-    void onSendFail(Backoffer & bo, const Exception & e, RPCContextPtr rpc_ctx);
+    void onSendFail(Backoffer & bo, const Exception & e, RPCContextPtr rpc_ctx) const;
 };
 
 } // namespace kv

--- a/include/pingcap/kv/Rpc.h
+++ b/include/pingcap/kv/Rpc.h
@@ -13,13 +13,12 @@ namespace pingcap
 {
 namespace kv
 {
-
 struct ConnArray
 {
     std::mutex mutex;
     std::string address;
 
-    size_t index;
+    size_t index = 0;
     std::vector<std::shared_ptr<KvConnClient>> vec;
 
     ConnArray() = default;
@@ -43,7 +42,7 @@ class RpcCall
     Logger * log;
 
 public:
-    RpcCall(std::shared_ptr<T> req_)
+    explicit RpcCall(std::shared_ptr<T> req_)
         : req(req_)
         , resp(std::make_shared<S>())
         , log(&Logger::get("pingcap.tikv"))
@@ -88,9 +87,9 @@ struct RpcClient
 
     std::map<std::string, ConnArrayPtr> conns;
 
-    RpcClient() {}
+    RpcClient() = default;
 
-    RpcClient(const ClusterConfig & config_)
+    explicit RpcClient(const ClusterConfig & config_)
         : config(config_)
     {}
 
@@ -101,25 +100,25 @@ struct RpcClient
     template <class T>
     void sendRequest(std::string addr, RpcCall<T> & rpc, int timeout)
     {
-        ConnArrayPtr connArray = getConnArray(addr);
-        auto connClient = connArray->get();
-        rpc.call(connClient, timeout);
+        ConnArrayPtr conn_array = getConnArray(addr);
+        auto conn_client = conn_array->get();
+        rpc.call(conn_client, timeout);
     }
 
     template <class T>
     auto sendStreamRequest(std::string addr, grpc::ClientContext * context, RpcCall<T> & rpc)
     {
-        ConnArrayPtr connArray = getConnArray(addr);
-        auto connClient = connArray->get();
-        return rpc.callStream(context, connClient);
+        ConnArrayPtr conn_array = getConnArray(addr);
+        auto conn_client = conn_array->get();
+        return rpc.callStream(context, conn_client);
     }
 
     template <class T>
     auto sendStreamRequestAsync(std::string addr, grpc::ClientContext * context, RpcCall<T> & rpc, grpc::CompletionQueue & cq, void * call)
     {
-        ConnArrayPtr connArray = getConnArray(addr);
-        auto connClient = connArray->get();
-        return rpc.callStreamAsync(context, connClient, cq, call);
+        ConnArrayPtr conn_array = getConnArray(addr);
+        auto conn_client = conn_array->get();
+        return rpc.callStreamAsync(context, conn_client, cq, call);
     }
 };
 

--- a/include/pingcap/kv/Scanner.h
+++ b/include/pingcap/kv/Scanner.h
@@ -8,7 +8,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 inline std::string prefixNext(const std::string & str)
 {
     auto new_str = str;

--- a/include/pingcap/kv/Snapshot.h
+++ b/include/pingcap/kv/Snapshot.h
@@ -7,7 +7,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 struct Scanner;
 
 struct Snapshot
@@ -20,7 +19,7 @@ struct Snapshot
         : cluster(cluster_)
         , version(version_)
     {}
-    Snapshot(Cluster * cluster_)
+    explicit Snapshot(Cluster * cluster_)
         : cluster(cluster_)
         , version(cluster_->pd_client->getTS())
     {}

--- a/include/pingcap/kv/internal/conn.h
+++ b/include/pingcap/kv/internal/conn.h
@@ -14,7 +14,7 @@ struct KvConnClient
     KvConnClient(std::string addr, const ClusterConfig & config)
     {
         grpc::ChannelArguments ch_args;
-        // set max size that grpc client can recieve to max value.
+        // set max size that grpc client can receive to max value.
         ch_args.SetMaxReceiveMessageSize(-1);
         ch_args.SetInt(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS, 1 * 1000);
         ch_args.SetInt(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS, 3 * 1000);

--- a/include/pingcap/kv/internal/type_traits.h
+++ b/include/pingcap/kv/internal/type_traits.h
@@ -9,7 +9,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 template <class T>
 struct RpcTypeTraits
 {

--- a/include/pingcap/pd/Client.h
+++ b/include/pingcap/pd/Client.h
@@ -87,7 +87,7 @@ private:
 
     pdpb::GetMembersResponse getMembers(std::string);
 
-    pdpb::RequestHeader * requestHeader();
+    pdpb::RequestHeader * requestHeader() const;
 
     std::shared_ptr<PDConnClient> getOrCreateGRPCConn(const std::string &);
 

--- a/include/pingcap/pd/CodecClient.h
+++ b/include/pingcap/pd/CodecClient.h
@@ -28,7 +28,7 @@ struct CodecClient : public Client
         return std::make_pair(processRegionResult(region), leader);
     }
 
-    metapb::Region processRegionResult(metapb::Region & region)
+    static metapb::Region processRegionResult(metapb::Region & region)
     {
         region.set_start_key(decodeBytes(region.start_key()));
         region.set_end_key(decodeBytes(region.end_key()));
@@ -40,9 +40,9 @@ private:
     static constexpr uint8_t ENC_GROUP_SIZE = 8;
     static constexpr char ENC_ASC_PADDING[ENC_GROUP_SIZE] = {0};
 
-    std::string encodeBytes(const std::string & raw)
+    static std::string encodeBytes(const std::string & raw)
     {
-        if (raw.size() == 0)
+        if (raw.empty())
             return "";
         std::stringstream ss;
         size_t len = raw.size();
@@ -61,15 +61,15 @@ private:
                 ss.write(raw.data() + index, remain);
                 ss.write(ENC_ASC_PADDING, pad);
             }
-            ss.put(static_cast<char>(ENC_MARKER - (uint8_t)pad));
+            ss.put(static_cast<char>(ENC_MARKER - static_cast<uint8_t>(pad)));
             index += ENC_GROUP_SIZE;
         }
         return ss.str();
     }
 
-    std::string decodeBytes(const std::string & raw)
+    static std::string decodeBytes(const std::string & raw)
     {
-        if (raw.size() == 0)
+        if (raw.empty())
             return "";
         std::stringstream ss;
         int cursor = 0;
@@ -78,7 +78,7 @@ private:
             size_t next_cursor = cursor + 9;
             if (next_cursor > raw.size())
                 throw Exception("Wrong format, cursor over buffer size. (DecodeBytes)", ErrorCodes::LogicalError);
-            uint8_t marker = (uint8_t)raw[cursor + 8];
+            auto marker = static_cast<uint8_t>(raw[cursor + 8]);
             uint8_t pad_size = ENC_MARKER - marker;
 
             if (pad_size > 8)

--- a/include/pingcap/pd/IClient.h
+++ b/include/pingcap/pd/IClient.h
@@ -12,13 +12,12 @@ namespace pingcap
 {
 namespace pd
 {
-
 class IClient
 {
 public:
     //    virtual uint64_t getClusterID() = 0;
 
-    virtual ~IClient() {}
+    virtual ~IClient() = default;
 
     virtual uint64_t getTS() = 0;
 

--- a/include/pingcap/pd/MockPDClient.h
+++ b/include/pingcap/pd/MockPDClient.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <pingcap/Exception.h>
 #include <pingcap/pd/IClient.h>
 
 #include <limits>
@@ -8,7 +9,6 @@ namespace pingcap
 {
 namespace pd
 {
-
 using Clock = std::chrono::system_clock;
 
 class MockPDClient : public IClient
@@ -16,17 +16,17 @@ class MockPDClient : public IClient
 public:
     MockPDClient() = default;
 
-    ~MockPDClient() override {}
+    ~MockPDClient() override = default;
 
     uint64_t getGCSafePoint() override { return 10000000; }
 
     uint64_t getTS() override { return Clock::now().time_since_epoch().count(); }
 
-    std::pair<metapb::Region, metapb::Peer> getRegionByKey(const std::string &) override { throw "not implemented"; }
+    std::pair<metapb::Region, metapb::Peer> getRegionByKey(const std::string &) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
 
-    std::pair<metapb::Region, metapb::Peer> getRegionByID(uint64_t) override { throw "not implemented"; }
+    std::pair<metapb::Region, metapb::Peer> getRegionByID(uint64_t) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
 
-    metapb::Store getStore(uint64_t) override { throw "not implemented"; }
+    metapb::Store getStore(uint64_t) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
 
     bool isMock() override { return true; }
 };

--- a/include/pingcap/pd/Oracle.h
+++ b/include/pingcap/pd/Oracle.h
@@ -11,7 +11,6 @@ namespace pingcap
 {
 namespace pd
 {
-
 constexpr int physicalShiftBits = 18;
 
 inline int64_t extractPhysical(uint64_t ts)

--- a/src/RedactHelpers.cc
+++ b/src/RedactHelpers.cc
@@ -43,7 +43,7 @@ std::string Redact::keyToHexString(const char * key, size_t size)
     char *      pos = buf.data();
     for (size_t i = 0; i < size; ++i)
     {
-        writeHexByteUppercase((uint8_t)(key[i]), pos);
+        writeHexByteUppercase(static_cast<uint8_t>(key[i]), pos);
         pos += 2;
     }
     return buf;

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -50,7 +50,7 @@ std::vector<copTask> buildCopTasks(
     return tasks;
 }
 
-std::vector<copTask> ResponseIter::handle_task_impl(kv::Backoffer & bo, const copTask & task)
+std::vector<copTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const copTask & task)
 {
     auto req = std::make_shared<::coprocessor::Request>();
     req->set_tp(task.req->tp);
@@ -58,7 +58,7 @@ std::vector<copTask> ResponseIter::handle_task_impl(kv::Backoffer & bo, const co
     req->set_schema_ver(task.req->schema_version);
     req->set_data(task.req->data);
     req->set_is_cache_enabled(false);
-    for (auto ts : min_commit_ts_pushed.get_timestamps())
+    for (auto ts : min_commit_ts_pushed.getTimestamps())
     {
         req->mutable_context()->add_resolved_locks(ts);
     }
@@ -85,10 +85,10 @@ std::vector<copTask> ResponseIter::handle_task_impl(kv::Backoffer & bo, const co
         log->debug("encounter lock problem: " + resp->locked().DebugString());
         std::vector<uint64_t> pushed;
         std::vector<kv::LockPtr> locks{lock};
-        auto before_expired = cluster->lock_resolver->ResolveLocks(bo, task.req->start_ts, locks, pushed);
+        auto before_expired = cluster->lock_resolver->resolveLocks(bo, task.req->start_ts, locks, pushed);
         if (!pushed.empty())
         {
-            min_commit_ts_pushed.add_timestamps(pushed);
+            min_commit_ts_pushed.addTimestamps(pushed);
         }
         if (before_expired > 0)
         {
@@ -112,7 +112,7 @@ std::vector<copTask> ResponseIter::handle_task_impl(kv::Backoffer & bo, const co
     return {};
 }
 
-void ResponseIter::handle_task(const copTask & task)
+void ResponseIter::handleTask(const copTask & task)
 {
     std::unordered_map<uint64_t, kv::Backoffer> bo_maps;
     std::vector<copTask> remain_tasks({task});
@@ -125,7 +125,7 @@ void ResponseIter::handle_task(const copTask & task)
         {
             auto & current_task = remain_tasks[idx];
             auto new_tasks
-                = handle_task_impl(bo_maps.try_emplace(current_task.region_id.id, kv::copNextMaxBackoff).first->second, current_task);
+                = handleTaskImpl(bo_maps.try_emplace(current_task.region_id.id, kv::copNextMaxBackoff).first->second, current_task);
             if (!new_tasks.empty())
             {
                 remain_tasks.insert(remain_tasks.end(), new_tasks.begin(), new_tasks.end());

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -7,7 +7,6 @@ namespace pingcap
 {
 namespace coprocessor
 {
-
 using namespace std::chrono_literals;
 
 std::vector<copTask> buildCopTasks(
@@ -20,7 +19,7 @@ std::vector<copTask> buildCopTasks(
 {
     log->debug("build " + std::to_string(ranges.size()) + " ranges.");
     std::vector<copTask> tasks;
-    while (ranges.size() > 0)
+    while (!ranges.empty())
     {
         auto loc = cluster->region_cache->locateKey(bo, ranges[0].start_key);
 
@@ -127,7 +126,7 @@ void ResponseIter::handle_task(const copTask & task)
             auto & current_task = remain_tasks[idx];
             auto new_tasks
                 = handle_task_impl(bo_maps.try_emplace(current_task.region_id.id, kv::copNextMaxBackoff).first->second, current_task);
-            if (new_tasks.size() > 0)
+            if (!new_tasks.empty())
             {
                 remain_tasks.insert(remain_tasks.end(), new_tasks.begin(), new_tasks.end());
             }

--- a/src/kv/2pc.cc
+++ b/src/kv/2pc.cc
@@ -152,6 +152,7 @@ void TwoPhaseCommitter::prewriteSingleBatch(Backoffer & bo, const BatchKeys & ba
             {
                 for (auto & [k, v] : mutations)
                 {
+                    (void)v;
                     if (k == primary_lock)
                         continue;
                     auto * secondary = req->add_secondaries();

--- a/src/kv/2pc.cc
+++ b/src/kv/2pc.cc
@@ -8,7 +8,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 constexpr uint64_t managedLockTTL = 20000; // 20s
 
 constexpr uint64_t bytesPerMiB = 1024 * 1024;
@@ -23,7 +22,7 @@ uint64_t txnLockTTL(std::chrono::milliseconds start, uint64_t txn_size)
     if (txn_size >= txnCommitBatchSize)
     {
         uint64_t txn_size_mb = txn_size / bytesPerMiB;
-        lock_ttl = (uint64_t)(ttlFactor * sqrt(txn_size_mb));
+        lock_ttl = static_cast<uint64_t>(ttlFactor * sqrt(txn_size_mb));
         if (lock_ttl < defaultLockTTL)
         {
             lock_ttl = defaultLockTTL;

--- a/src/kv/Backoff.cc
+++ b/src/kv/Backoff.cc
@@ -5,7 +5,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 BackoffPtr newBackoff(BackoffType tp)
 {
     switch (tp)

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -8,7 +8,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 std::string Lock::toDebugString() const
 {
     return "key: " + Redact::keyToDebugString(key) + " primary: " + Redact::keyToDebugString(primary)
@@ -182,7 +181,7 @@ TxnStatus LockResolver::getTxnStatus(Backoffer & bo, uint64_t txn_id, const std:
         }
         if (response->has_error())
         {
-            auto & key_error = response->error();
+            const auto & key_error = response->error();
             if (key_error.has_txn_not_found())
             {
                 throw Exception("txn not found: ", ErrorCodes::TxnNotFound);
@@ -291,7 +290,7 @@ void LockResolver::resolvePessimisticLock(Backoffer & bo, LockPtr lock, std::uno
             bo.backoff(boRegionMiss, e);
             continue;
         }
-        auto & key_errors = response->errors();
+        const auto & key_errors = response->errors();
         if (!key_errors.empty())
         {
             log->error("unexpected resolve pessimistic lock err: " + key_errors[0].ShortDebugString());
@@ -317,7 +316,7 @@ void LockResolver::resolveLockAsync(Backoffer & bo, LockPtr lock, TxnStatus & st
     std::atomic<int> errors{};
     for (auto & pair : keys_by_region)
     {
-        auto & region_id = pair.first;
+        const auto & region_id = pair.first;
         auto & locks = pair.second;
         threads.emplace_back([&]() {
             try
@@ -360,7 +359,7 @@ void LockResolver::resolveRegionLocks(
 
     for (auto & key : keys)
     {
-        auto k = req->add_keys();
+        auto * k = req->add_keys();
         *k = key;
     }
 
@@ -406,7 +405,7 @@ AsyncResolveDataPtr LockResolver::checkAllSecondaries(Backoffer & bo, LockPtr lo
     std::atomic_int8_t errors{0};
     for (auto & pair : regions)
     {
-        auto & region_id = pair.first;
+        const auto & region_id = pair.first;
         auto & keys = pair.second;
         threads.emplace_back([&]() {
             try

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -16,7 +16,7 @@ std::string Lock::toDebugString() const
         + " ttl: " + std::to_string(ttl) + " type: " + std::to_string(lock_type);
 }
 
-int64_t LockResolver::ResolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed)
+int64_t LockResolver::resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed)
 {
     return resolveLocks(bo, caller_start_ts, locks, pushed, false);
 }

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -7,7 +7,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 RPCContextPtr RegionCache::getRPCContext(Backoffer & bo, const RegionVerID & id, const StoreType store_type)
 {
     for (;;)
@@ -99,7 +98,7 @@ KeyLocation RegionCache::locateKey(Backoffer & bo, const std::string & key)
 std::vector<metapb::Peer> RegionCache::selectTiFlashPeers(Backoffer & bo, const metapb::Region & meta)
 {
     std::vector<metapb::Peer> tiflash_peers;
-    for (auto & peer : meta.peers())
+    for (const auto & peer : meta.peers())
     {
         if (getStore(bo, peer.store_id()).store_type == StoreType::TiFlash)
         {
@@ -305,7 +304,7 @@ bool RegionCache::updateLeader(const RegionVerID & region_id, const metapb::Peer
     return true;
 }
 
-void RegionCache::onRegionStale(Backoffer & bo, RPCContextPtr ctx, const errorpb::EpochNotMatch & stale_epoch)
+void RegionCache::onRegionStale(Backoffer & /*bo*/, RPCContextPtr ctx, const errorpb::EpochNotMatch & stale_epoch)
 {
     log->information("region stale for region " + ctx->region.toString() + ".");
 

--- a/src/kv/RegionClient.cc
+++ b/src/kv/RegionClient.cc
@@ -4,12 +4,11 @@ namespace pingcap
 {
 namespace kv
 {
-
-void RegionClient::onRegionError(Backoffer & bo, RPCContextPtr rpc_ctx, const errorpb::Error & err)
+void RegionClient::onRegionError(Backoffer & bo, RPCContextPtr rpc_ctx, const errorpb::Error & err) const
 {
     if (err.has_not_leader())
     {
-        auto not_leader = err.not_leader();
+        const auto & not_leader = err.not_leader();
         if (not_leader.has_leader())
         {
             // don't backoff if a new leader is returned.
@@ -107,7 +106,7 @@ void RegionClient::onRegionError(Backoffer & bo, RPCContextPtr rpc_ctx, const er
     cluster->region_cache->dropRegion(rpc_ctx->region);
 }
 
-void RegionClient::onSendFail(Backoffer & bo, const Exception & e, RPCContextPtr rpc_ctx)
+void RegionClient::onSendFail(Backoffer & bo, const Exception & e, RPCContextPtr rpc_ctx) const
 {
     cluster->region_cache->onSendReqFail(rpc_ctx, e);
     // Retry on send request failure when it's not canceled.

--- a/src/kv/Rpc.cc
+++ b/src/kv/Rpc.cc
@@ -4,7 +4,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 ConnArray::ConnArray(size_t max_size, const std::string & addr, const ClusterConfig & config_)
     : address(addr)
     , index(0)

--- a/src/kv/Scanner.cc
+++ b/src/kv/Scanner.cc
@@ -93,7 +93,7 @@ void Scanner::getData(Backoffer & bo)
             auto lock = extractLockFromKeyErr(response->error());
             std::vector<LockPtr> locks{lock};
             std::vector<uint64_t> pushed{};
-            auto ms_before_expired = snap.cluster->lock_resolver->ResolveLocks(bo, snap.version, locks, pushed);
+            auto ms_before_expired = snap.cluster->lock_resolver->resolveLocks(bo, snap.version, locks, pushed);
             if (ms_before_expired > 0)
             {
                 bo.backoffWithMaxSleep(

--- a/src/kv/Scanner.cc
+++ b/src/kv/Scanner.cc
@@ -30,7 +30,7 @@ void Scanner::next()
         }
 
         auto & current = cache[idx];
-        if (end_key.size() > 0 && current.key() >= end_key)
+        if (!end_key.empty() && current.key() >= end_key)
         {
             eof = true;
             valid = false;
@@ -58,11 +58,11 @@ void Scanner::getData(Backoffer & bo)
     {
         auto loc = snap.cluster->region_cache->locateKey(bo, next_start_key);
         auto req_end_key = end_key;
-        if (req_end_key.size() > 0 && loc.end_key.size() > 0 && loc.end_key < req_end_key)
+        if (!req_end_key.empty() && !loc.end_key.empty() && loc.end_key < req_end_key)
             req_end_key = loc.end_key;
 
 
-        auto regionClient = RegionClient(snap.cluster, loc.region);
+        auto region_client = RegionClient(snap.cluster, loc.region);
         auto request = std::make_shared<kvrpcpb::ScanRequest>();
         request->set_start_key(next_start_key);
         request->set_end_key(req_end_key);
@@ -70,14 +70,14 @@ void Scanner::getData(Backoffer & bo)
         request->set_version(snap.version);
         request->set_key_only(false);
 
-        auto context = request->mutable_context();
+        auto * context = request->mutable_context();
         context->set_priority(::kvrpcpb::Normal);
         context->set_not_fill_cache(false);
 
         std::shared_ptr<kvrpcpb::ScanResponse> response;
         try
         {
-            response = regionClient.sendReqToRegion(bo, request);
+            response = region_client.sendReqToRegion(bo, request);
         }
         catch (Exception & e)
         {
@@ -125,7 +125,7 @@ void Scanner::getData(Backoffer & bo)
             next_start_key = loc.end_key;
 
             // If the end key is empty, it infers this region is last and should stop scan.
-            if (loc.end_key.size() == 0 || (next_start_key) >= end_key)
+            if (loc.end_key.empty() || (next_start_key) >= end_key)
             {
                 eof = true;
             }
@@ -133,8 +133,8 @@ void Scanner::getData(Backoffer & bo)
             return;
         }
 
-        auto lastKey = cache.back();
-        next_start_key = alphabeticalNext(lastKey.key());
+        auto last_key = cache.back();
+        next_start_key = alphabeticalNext(last_key.key());
         log->trace("scan next key: " + next_start_key);
         return;
     }

--- a/src/kv/Snapshot.cc
+++ b/src/kv/Snapshot.cc
@@ -27,7 +27,7 @@ std::string Snapshot::Get(Backoffer & bo, const std::string & key)
         ::kvrpcpb::Context * context = request->mutable_context();
         context->set_priority(::kvrpcpb::Normal);
         context->set_not_fill_cache(false);
-        for (auto ts : min_commit_ts_pushed.get_timestamps())
+        for (auto ts : min_commit_ts_pushed.getTimestamps())
         {
             context->add_resolved_locks(ts);
         }
@@ -50,11 +50,11 @@ std::string Snapshot::Get(Backoffer & bo, const std::string & key)
             auto lock = extractLockFromKeyErr(response->error());
             std::vector<LockPtr> locks{lock};
             std::vector<uint64_t> pushed;
-            auto before_expired = cluster->lock_resolver->ResolveLocks(bo, version, locks, pushed);
+            auto before_expired = cluster->lock_resolver->resolveLocks(bo, version, locks, pushed);
 
             if (!pushed.empty())
             {
-                min_commit_ts_pushed.add_timestamps(pushed);
+                min_commit_ts_pushed.addTimestamps(pushed);
             }
             if (before_expired > 0)
             {

--- a/src/kv/Snapshot.cc
+++ b/src/kv/Snapshot.cc
@@ -7,7 +7,6 @@ namespace pingcap
 {
 namespace kv
 {
-
 constexpr int scan_batch_size = 256;
 
 //bool extractLockFromKeyErr()

--- a/src/test/coprocessor_test.cc
+++ b/src/test/coprocessor_test.cc
@@ -15,7 +15,6 @@ std::vector<copTask> buildCopTasks(kv::Backoffer & bo, kv::Cluster * cluster, st
 
 namespace
 {
-
 using namespace pingcap;
 using namespace pingcap::kv;
 

--- a/src/test/io_or_region_error_get_test.cc
+++ b/src/test/io_or_region_error_get_test.cc
@@ -10,7 +10,6 @@
 
 namespace
 {
-
 using namespace pingcap;
 using namespace pingcap::kv;
 

--- a/src/test/lock_resolve_test.cc
+++ b/src/test/lock_resolve_test.cc
@@ -12,7 +12,6 @@
 
 namespace
 {
-
 using namespace pingcap;
 using namespace pingcap::kv;
 

--- a/src/test/mock_tikv.h
+++ b/src/test/mock_tikv.h
@@ -16,7 +16,6 @@ namespace kv
 {
 namespace mockkv
 {
-
 using namespace Poco::Net;
 
 constexpr char mock_server[] = "http://127.0.0.1:2378";

--- a/src/test/region_split_test.cc
+++ b/src/test/region_split_test.cc
@@ -10,7 +10,6 @@
 
 namespace
 {
-
 using namespace pingcap;
 using namespace pingcap::kv;
 

--- a/src/test/test_helper.h
+++ b/src/test/test_helper.h
@@ -6,7 +6,6 @@
 
 namespace
 {
-
 using namespace pingcap;
 using namespace pingcap::kv;
 


### PR DESCRIPTION
close https://github.com/tikv/client-c/issues/81

* Add .clang-tidy lint check
* Fix clang-tidy lint
* Suppress an unused warning

Signed-off-by: JaySon-Huang <tshent@qq.com>