### PR TITLE
Fix wrong usage about Poco::URI to support ipv6

### DIFF
--- a/src/pd/Client.cc
+++ b/src/pd/Client.cc
@@ -78,7 +78,7 @@ std::shared_ptr<Client::PDConnClient> Client::getOrCreateGRPCConn(const std::str
     }
     // TODO Check Auth
     Poco::URI uri(addr);
-    auto client_ptr = std::make_shared<PDConnClient>(uri.getHost() + ":" + std::to_string(uri.getPort()), config);
+    auto client_ptr = std::make_shared<PDConnClient>(uri.getAuthority(), config);
     channel_map[addr] = client_ptr;
 
     return client_ptr;


### PR DESCRIPTION
Ref https://github.com/pingcap/tiflash/issues/5247

Host of ipv6 addr `http://[::1]:2379` is `::1`. To visit ipv6 host, it's necessary to encode the IPv6 IP number in square brackets according to [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt). We need to use [URI::getAuthority](https://github.com/pingcap/poco/blob/151304135eb92b68e05e011ef3322efa062d743f/Foundation/src/URI.cpp#L278).