### PR TITLE
*: Fix missing header; Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,92 @@
+---
+BasedOnStyle:  Google
+Language:        Cpp
+AlignAfterOpenBracket: Align
+AlignEscapedNewlines: Left
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: Inline
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping: 
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum : true
+    AfterFunction : true
+    AfterNamespace : true
+    AfterStruct : true
+    AfterUnion : true
+    BeforeCatch : true
+    BeforeElse : true
+    IndentBraces : false
+    SplitEmptyFunction: false
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList : BeforeComma
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+Cpp11BracedListStyle: true
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: true
+FixNamespaceComments: true
+IndentCaseLabels: false
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 2
+#PPIndentWidth: 2  # clang-format version 12.0.0 doesn't support yet
+PointerAlignment: Middle
+ReflowComments: false
+SortIncludes: true
+SpaceAfterTemplateKeyword: true
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never
+
+# Not changed:
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands:   false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: All
+BreakBeforeTernaryOperators: true
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+...

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ cmake-build*
 *.swp
 *.swo
 tags
-.clang-format
 .vscode
 
 # vscode clangd cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 project(kvClient)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-narrowing")

--- a/include/pingcap/Log.h
+++ b/include/pingcap/Log.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <Poco/Logger.h>
 
 namespace pingcap

--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -29,15 +29,18 @@ struct KeyRange
         : start_key(start_key_)
         , end_key(end_key_)
     {}
-    KeyRange(KeyRange &&) = default;
-    KeyRange(const KeyRange &) = default;
-    KeyRange & operator=(const KeyRange &) = default;
-    KeyRange & operator=(KeyRange &&) = default;
-    void set_pb_range(::coprocessor::KeyRange * range) const
+
+    void setKeyRange(::coprocessor::KeyRange * range) const
     {
         range->set_start(start_key);
         range->set_end(end_key);
     }
+
+    KeyRange(KeyRange &&) = default;
+    KeyRange(const KeyRange &) = default;
+    KeyRange & operator=(const KeyRange &) = default;
+    KeyRange & operator=(KeyRange &&) = default;
+
     bool operator<(const KeyRange & rhs) const { return start_key < rhs.start_key; }
 };
 

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -54,7 +54,10 @@ struct RegionVerID
     bool operator==(const RegionVerID & rhs) const { return id == rhs.id && conf_ver == rhs.conf_ver && ver == rhs.ver; }
 
     // for debug output
-    std::string toString() const { return "{" + std::to_string(id) + "," + std::to_string(conf_ver) + "," + std::to_string(ver) + "}"; }
+    std::string toString() const
+    {
+        return "{" + std::to_string(id) + "," + std::to_string(conf_ver) + "," + std::to_string(ver) + "}";
+    }
 };
 
 } // namespace kv
@@ -148,8 +151,11 @@ struct RPCContext
         , addr(addr_)
     {}
 
-    std::string toString() const { return "region id: " + std::to_string(region.id) + ", meta: " + meta.DebugString() + ", peer: "
-                                   + peer.DebugString() + ", addr: " + addr; }
+    std::string toString() const
+    {
+        return "region id: " + std::to_string(region.id) + ", meta: " + meta.DebugString() + ", peer: "
+            + peer.DebugString() + ", addr: " + addr;
+    }
 };
 
 using RPCContextPtr = std::shared_ptr<RPCContext>;

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -182,9 +182,9 @@ public:
 
     Store getStore(Backoffer & bo, uint64_t id);
 
-    std::pair<std::unordered_map<RegionVerID, std::vector<std::string>>, RegionVerID> groupKeysByRegion(
-        Backoffer & bo,
-        const std::vector<std::string> & keys);
+    std::pair<std::unordered_map<RegionVerID, std::vector<std::string>>, RegionVerID>
+    groupKeysByRegion(Backoffer & bo,
+                      const std::vector<std::string> & keys);
 
 private:
     RegionPtr loadRegionByKey(Backoffer & bo, const std::string & key);

--- a/include/pingcap/kv/internal/conn.h
+++ b/include/pingcap/kv/internal/conn.h
@@ -1,3 +1,6 @@
+#pragma once
+#include <grpcpp/create_channel.h>
+#include <kvproto/tikvpb.grpc.pb.h>
 #include <pingcap/Config.h>
 
 namespace pingcap

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -65,7 +65,7 @@ std::vector<copTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const copT
     for (const auto & range : task.ranges)
     {
         auto * pb_range = req->add_ranges();
-        range.set_pb_range(pb_range);
+        range.setKeyRange(pb_range);
     }
 
     kv::RegionClient client(cluster, task.region_id);

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -323,17 +323,16 @@ void RegionCache::onRegionStale(Backoffer & /*bo*/, RPCContextPtr ctx, const err
     }
 }
 
-std::pair<std::unordered_map<RegionVerID, std::vector<std::string>>, RegionVerID> RegionCache::groupKeysByRegion(
-    Backoffer & bo,
-    const std::vector<std::string> & keys)
+std::pair<std::unordered_map<RegionVerID, std::vector<std::string>>, RegionVerID>
+RegionCache::groupKeysByRegion(Backoffer & bo,
+                               const std::vector<std::string> & keys)
 {
     std::unordered_map<RegionVerID, std::vector<std::string>> result_map;
     KeyLocation loc;
     RegionVerID first;
     bool first_found = false;
-    for (size_t i = 0; i < keys.size(); i++)
+    for (const auto & key : keys)
     {
-        const std::string & key = keys[i];
         if (!first_found || !loc.contains(key))
         {
             loc = locateKey(bo, key);


### PR DESCRIPTION
* Some header file don't have `#pragma once` line
* Add `.clang-format` for work as a standalone project without tiflash
* Update cmake_minimum_required version to 3.10 to fix the warning
  * CMake 3.10 is old enough to be available in most platform including Ubuntu 18.04 LTS https://pkgs.org/download/cmake
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```