### PR TITLE
Add metadata interface on coptask

### DIFF
--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -57,6 +57,7 @@ struct copTask
     std::vector<KeyRange> ranges;
     RequestPtr req;
     kv::StoreType store_type;
+    kv::GRPCMetaData meta_data;
 };
 
 class ResponseIter
@@ -191,7 +192,8 @@ std::vector<copTask> buildCopTasks(
     std::vector<KeyRange> ranges,
     RequestPtr cop_req,
     kv::StoreType store_type,
-    Logger * log);
+    Logger * log,
+    kv::GRPCMetaData meta_data = {});
 
 } // namespace coprocessor
 } // namespace pingcap

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -37,7 +37,7 @@ struct RegionClient
 
     // This method send a request to region, but is NOT Thread-Safe !!
     template <typename T>
-    auto sendReqToRegion(Backoffer & bo, std::shared_ptr<T> req, int timeout = dailTimeout, StoreType store_type = StoreType::TiKV)
+    auto sendReqToRegion(Backoffer & bo, std::shared_ptr<T> req, int timeout = dailTimeout, StoreType store_type = StoreType::TiKV, kv::GRPCMetaData meta_data = {})
     {
         RpcCall<T> rpc(req);
         for (;;)
@@ -55,7 +55,7 @@ struct RegionClient
             rpc.setCtx(ctx);
             try
             {
-                cluster->rpc_client->sendRequest(store_addr, rpc, timeout);
+                cluster->rpc_client->sendRequest(store_addr, rpc, timeout, meta_data);
             }
             catch (const Exception & e)
             {

--- a/include/pingcap/kv/Rpc.h
+++ b/include/pingcap/kv/Rpc.h
@@ -29,6 +29,7 @@ struct ConnArray
 };
 
 using ConnArrayPtr = std::shared_ptr<ConnArray>;
+using GRPCMetaData = std::multimap<std::string, std::string>;
 
 // RpcCall holds the request and response, and delegates RPC calls.
 template <class T>
@@ -58,10 +59,12 @@ public:
 
     std::shared_ptr<S> getResp() { return resp; }
 
-    void call(std::shared_ptr<KvConnClient> client, int timeout)
+    void call(std::shared_ptr<KvConnClient> client, int timeout, GRPCMetaData meta_data = {})
     {
         grpc::ClientContext context;
         context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(timeout));
+        for (auto & it : meta_data)
+            context.AddMetadata(it.first, it.second);
         auto status = Trait::doRPCCall(&context, client, *req, resp.get());
         if (!status.ok())
         {
@@ -98,11 +101,11 @@ struct RpcClient
     ConnArrayPtr createConnArray(const std::string & addr);
 
     template <class T>
-    void sendRequest(std::string addr, RpcCall<T> & rpc, int timeout)
+    void sendRequest(std::string addr, RpcCall<T> & rpc, int timeout, GRPCMetaData meta_data = {})
     {
         ConnArrayPtr conn_array = getConnArray(addr);
         auto conn_client = conn_array->get();
-        rpc.call(conn_client, timeout);
+        rpc.call(conn_client, timeout, meta_data);
     }
 
     template <class T>


### PR DESCRIPTION
grpc can use context to pass some debug info, this pr add an interface for it.

after this pr, you can add your info to copTask before passing tasks to ResponseIter.

tested with TiFlash
<img width="600" alt="image" src="https://user-images.githubusercontent.com/30543181/199659200-cf12d5be-6671-438e-bf01-010b4f87cdda.png">
