### PR TITLE
support <engine_role, write> in disaggregated tiflash mode

### DIFF
--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -116,10 +116,10 @@ public:
     };
 
     ResponseIter(std::vector<CopTask> && tasks_,
-            kv::Cluster * cluster_,
-            int concurrency_,
-            Logger * log_,
-            const kv::LabelFilter & tiflash_label_filter_ = kv::labelFilterInvalid)
+                 kv::Cluster * cluster_,
+                 int concurrency_,
+                 Logger * log_,
+                 const kv::LabelFilter & tiflash_label_filter_ = kv::labelFilterInvalid)
         : tasks(std::move(tasks_))
         , cluster(cluster_)
         , concurrency(concurrency_)

--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -239,6 +239,7 @@ std::vector<BatchCopTask> buildBatchCopTasks(
     const std::vector<int64_t> & physical_table_ids,
     const std::vector<KeyRanges> & ranges_for_each_physical_table,
     kv::StoreType store_type,
+    const kv::LabelFilter & label_filter,
     Logger * log);
 
 namespace details

--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -115,12 +115,17 @@ public:
         const std::string & data() const { return resp->data(); }
     };
 
-    ResponseIter(std::vector<CopTask> && tasks_, kv::Cluster * cluster_, int concurrency_, Logger * log_)
+    ResponseIter(std::vector<CopTask> && tasks_,
+            kv::Cluster * cluster_,
+            int concurrency_,
+            Logger * log_,
+            const kv::LabelFilter & tiflash_label_filter_ = kv::labelFilterInvalid)
         : tasks(std::move(tasks_))
         , cluster(cluster_)
         , concurrency(concurrency_)
         , unfinished_thread(0)
         , cancelled(false)
+        , tiflash_label_filter(tiflash_label_filter_)
         , log(log_)
     {}
 
@@ -217,6 +222,7 @@ private:
     std::atomic_int unfinished_thread;
     std::atomic_bool cancelled;
     std::condition_variable cond_var;
+    kv::LabelFilter tiflash_label_filter;
 
     Logger * log;
 };

--- a/include/pingcap/kv/2pc.h
+++ b/include/pingcap/kv/2pc.h
@@ -188,7 +188,7 @@ private:
         {
             if constexpr (action == ActionCommit)
             {
-                fiu_do_on("all commit fail", return );
+                fiu_do_on("all commit fail", return);
             }
             doActionOnBatches<action>(bo, std::vector<BatchKeys>(batches.begin(), batches.begin() + 1));
             batches = std::vector<BatchKeys>(batches.begin() + 1, batches.end());

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -42,7 +42,6 @@ struct Cluster
     {
         pd_client->update(pd_addrs, config);
         rpc_client->update(config);
-        
     }
 
     // TODO: When the cluster is closed, we should release all the resources

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -122,7 +122,7 @@ struct Region
 };
 
 using RegionPtr = std::shared_ptr<Region>;
-using LabelFilter = std::function<bool(const std::map<std::string, std::string> &)>;
+using LabelFilter = bool(*)(const std::map<std::string, std::string> &);
 
 struct KeyLocation
 {
@@ -175,7 +175,7 @@ public:
         , log(&Logger::get("pingcap.tikv"))
     {}
 
-    RPCContextPtr getRPCContext(Backoffer & bo, const RegionVerID & id, StoreType store_type, bool load_balance, const LabelFilter & label_filter);
+    RPCContextPtr getRPCContext(Backoffer & bo, const RegionVerID & id, StoreType store_type, bool load_balance, const LabelFilter & tiflash_label_filter);
 
     bool updateLeader(const RegionVerID & region_id, const metapb::Peer & leader);
 
@@ -251,10 +251,12 @@ static const std::string EngineRoleLabelKey = "engine_role";
 static const std::string EngineRoleWrite = "write";
 
 bool hasLabel(const std::map<std::string, std::string> & labels, const std::string & key, const std::string & val);
+// Returns false means label doesn't match, and will ignore this store.
 bool labelFilterOnlyTiFlashWriteNode(const std::map<std::string, std::string> & labels);
 bool labelFilterNoTiFlashWriteNode(const std::map<std::string, std::string> & labels);
 bool labelFilterAllTiFlashNode(const std::map<std::string, std::string> & labels);
 bool labelFilterAllNode(const std::map<std::string, std::string> &);
+bool labelFilterInvalid(const std::map<std::string, std::string> &);
 
 } // namespace kv
 } // namespace pingcap

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -122,7 +122,7 @@ struct Region
 };
 
 using RegionPtr = std::shared_ptr<Region>;
-using LabelFilter = bool(*)(const std::map<std::string, std::string> &);
+using LabelFilter = bool (*)(const std::map<std::string, std::string> &);
 
 struct KeyLocation
 {

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -42,7 +42,7 @@ struct RegionClient
         RpcCall<T> rpc(req);
         for (;;)
         {
-            RPCContextPtr ctx = cluster->region_cache->getRPCContext(bo, region_id, store_type, true);
+            RPCContextPtr ctx = cluster->region_cache->getRPCContext(bo, region_id, store_type, /*load_balance=*/true, kv::labelFilterNoTiFlashWriteNode);
             if (ctx == nullptr)
             {
                 // If the region is not found in cache, it must be out

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -37,12 +37,21 @@ struct RegionClient
 
     // This method send a request to region, but is NOT Thread-Safe !!
     template <typename T>
-    auto sendReqToRegion(Backoffer & bo, std::shared_ptr<T> req, int timeout = dailTimeout, StoreType store_type = StoreType::TiKV, kv::GRPCMetaData meta_data = {})
+    auto sendReqToRegion(Backoffer & bo,
+            std::shared_ptr<T> req,
+            const LabelFilter & tiflash_label_filter = kv::labelFilterInvalid,
+            int timeout = dailTimeout,
+            StoreType store_type = StoreType::TiKV,
+            kv::GRPCMetaData meta_data = {})
     {
         RpcCall<T> rpc(req);
+        if (store_type == kv::StoreType::TiFlash && tiflash_label_filter == kv::labelFilterInvalid)
+        {
+            throw Exception("should setup proper label_filter for tiflash");
+        }
         for (;;)
         {
-            RPCContextPtr ctx = cluster->region_cache->getRPCContext(bo, region_id, store_type, /*load_balance=*/true, kv::labelFilterNoTiFlashWriteNode);
+            RPCContextPtr ctx = cluster->region_cache->getRPCContext(bo, region_id, store_type, /*load_balance=*/true, tiflash_label_filter);
             if (ctx == nullptr)
             {
                 // If the region is not found in cache, it must be out

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -38,11 +38,11 @@ struct RegionClient
     // This method send a request to region, but is NOT Thread-Safe !!
     template <typename T>
     auto sendReqToRegion(Backoffer & bo,
-            std::shared_ptr<T> req,
-            const LabelFilter & tiflash_label_filter = kv::labelFilterInvalid,
-            int timeout = dailTimeout,
-            StoreType store_type = StoreType::TiKV,
-            kv::GRPCMetaData meta_data = {})
+                         std::shared_ptr<T> req,
+                         const LabelFilter & tiflash_label_filter = kv::labelFilterInvalid,
+                         int timeout = dailTimeout,
+                         StoreType store_type = StoreType::TiKV,
+                         kv::GRPCMetaData meta_data = {})
     {
         RpcCall<T> rpc(req);
         if (store_type == kv::StoreType::TiFlash && tiflash_label_filter == kv::labelFilterInvalid)

--- a/include/pingcap/kv/internal/type_traits.h
+++ b/include/pingcap/kv/internal/type_traits.h
@@ -15,21 +15,24 @@ struct RpcTypeTraits
 };
 
 // Note that this macro is only applicable for grpc unary call
-#define PINGCAP_DEFINE_TRAITS(NAMESPACE, NAME, METHOD)            \
-    template <>                                                   \
-    struct RpcTypeTraits<::NAMESPACE::NAME##Request>              \
-    {                                                             \
-        using RequestType = ::NAMESPACE::NAME##Request;           \
-        using ResultType = ::NAMESPACE::NAME##Response;           \
-        static const char * err_msg() { return #NAME " Failed"; } \
-        static ::grpc::Status doRPCCall(                          \
-            grpc::ClientContext * context,                        \
-            std::shared_ptr<KvConnClient> client,                 \
-            const RequestType & req,                              \
-            ResultType * res)                                     \
-        {                                                         \
-            return client->stub->METHOD(context, req, res);       \
-        }                                                         \
+#define PINGCAP_DEFINE_TRAITS(NAMESPACE, NAME, METHOD)      \
+    template <>                                             \
+    struct RpcTypeTraits<::NAMESPACE::NAME##Request>        \
+    {                                                       \
+        using RequestType = ::NAMESPACE::NAME##Request;     \
+        using ResultType = ::NAMESPACE::NAME##Response;     \
+        static const char * err_msg()                       \
+        {                                                   \
+            return #NAME " Failed";                         \
+        }                                                   \
+        static ::grpc::Status doRPCCall(                    \
+            grpc::ClientContext * context,                  \
+            std::shared_ptr<KvConnClient> client,           \
+            const RequestType & req,                        \
+            ResultType * res)                               \
+        {                                                   \
+            return client->stub->METHOD(context, req, res); \
+        }                                                   \
     };
 
 PINGCAP_DEFINE_TRAITS(kvrpcpb, SplitRegion, SplitRegion)

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -427,16 +427,21 @@ std::vector<BatchCopTask> buildBatchCopTasks(
         balance_elapsed += std::chrono::duration_cast<std::chrono::milliseconds>(balance_end - balance_start).count();
 
         // For partition table, we need to move region info from task.region_infos to task.table_regions.
-        if (is_partition_table_scan) {
-            for (auto & task : batch_cop_tasks) {
+        if (is_partition_table_scan)
+        {
+            for (auto & task : batch_cop_tasks)
+            {
                 std::vector<pingcap::coprocessor::TableRegions> partition_table_regions(physical_table_ids.size());
-                for (const auto & region_info : task.region_infos) {
+                for (const auto & region_info : task.region_infos)
+                {
                     const auto partition_index = region_info.partition_index;
                     partition_table_regions[partition_index].physical_table_id = physical_table_ids[partition_index];
                     partition_table_regions[partition_index].region_infos.push_back(region_info);
                 }
-                for (const auto & partition_table_region : partition_table_regions) {
-                    if (partition_table_region.region_infos.empty()) {
+                for (const auto & partition_table_region : partition_table_regions)
+                {
+                    if (partition_table_region.region_infos.empty())
+                    {
                         continue;
                     }
                     task.table_regions.push_back(partition_table_region);
@@ -446,14 +451,9 @@ std::vector<BatchCopTask> buildBatchCopTasks(
         }
         auto end = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-        if (elapsed >= 500) {
-            log->warning("buildBatchCopTasks takes too long. total elapsed: " + std::to_string(elapsed) + "ms" +
-                    ", build cop_task elapsed: " + std::to_string(cop_task_elapsed) + "ms" +
-                    ", build batch_cop_task elapsed: " + std::to_string(batch_cop_task_elapsed) + "ms" +
-                    ", balance elapsed: " + std::to_string(balance_elapsed) + "ms" +
-                    ", cop_task num: " + std::to_string(cop_tasks.size()) +
-                    ", batch_cop_task num: " + std::to_string(batch_cop_tasks.size()) +
-                    ", retry_num: " + std::to_string(retry_num));
+        if (elapsed >= 500)
+        {
+            log->warning("buildBatchCopTasks takes too long. total elapsed: " + std::to_string(elapsed) + "ms" + ", build cop_task elapsed: " + std::to_string(cop_task_elapsed) + "ms" + ", build batch_cop_task elapsed: " + std::to_string(batch_cop_task_elapsed) + "ms" + ", balance elapsed: " + std::to_string(balance_elapsed) + "ms" + ", cop_task num: " + std::to_string(cop_tasks.size()) + ", batch_cop_task num: " + std::to_string(batch_cop_tasks.size()) + ", retry_num: " + std::to_string(retry_num));
         }
         return batch_cop_tasks;
     }

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -483,7 +483,7 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
     std::shared_ptr<::coprocessor::Response> resp;
     try
     {
-        resp = client.sendReqToRegion(bo, req, kv::copTimeout, task.store_type, task.meta_data);
+        resp = client.sendReqToRegion(bo, req, tiflash_label_filter, kv::copTimeout, task.store_type, task.meta_data);
     }
     catch (Exception & e)
     {

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -444,7 +444,7 @@ bool labelFilterAllNode(const std::map<std::string, std::string> &)
 
 bool labelFilterInvalid(const std::map<std::string, std::string> &)
 {
-    return false;
+    throw Exception("invalid label_filter", ErrorCodes::LogicalError);
 }
 } // namespace kv
 } // namespace pingcap

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -8,7 +8,8 @@ namespace pingcap
 namespace kv
 {
 // load_balance is an option, becase if store fail, it may cause batchCop fail.
-RPCContextPtr RegionCache::getRPCContext(Backoffer & bo, const RegionVerID & id, const StoreType store_type, bool load_balance, const LabelFilter & label_filter)
+// For now, label_filter only works for tiflash.
+RPCContextPtr RegionCache::getRPCContext(Backoffer & bo, const RegionVerID & id, const StoreType store_type, bool load_balance, const LabelFilter & tiflash_label_filter)
 {
     for (;;)
     {
@@ -27,7 +28,7 @@ RPCContextPtr RegionCache::getRPCContext(Backoffer & bo, const RegionVerID & id,
         else
         {
             // can access to all tiflash peers
-            peers = selectTiFlashPeers(bo, meta, label_filter);
+            peers = selectTiFlashPeers(bo, meta, tiflash_label_filter);
             if (load_balance)
                 start_index = ++region->work_tiflash_peer_idx;
             else
@@ -439,6 +440,11 @@ bool labelFilterAllTiFlashNode(const std::map<std::string, std::string> & labels
 bool labelFilterAllNode(const std::map<std::string, std::string> &)
 {
     return true;
+}
+
+bool labelFilterInvalid(const std::map<std::string, std::string> &)
+{
+    return false;
 }
 } // namespace kv
 } // namespace pingcap

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -414,7 +414,7 @@ bool hasLabel(const std::map<std::string, std::string> & labels, const std::stri
 {
     for (const auto & label : labels)
     {
-        if (label.first ==  key && label.second == val)
+        if (label.first == key && label.second == val)
             return true;
     }
     return false;
@@ -422,14 +422,12 @@ bool hasLabel(const std::map<std::string, std::string> & labels, const std::stri
 
 bool labelFilterOnlyTiFlashWriteNode(const std::map<std::string, std::string> & labels)
 {
-    return hasLabel(labels, EngineLabelKey, EngineLabelTiFlash) &&
-        hasLabel(labels, EngineRoleLabelKey, EngineRoleWrite);
+    return hasLabel(labels, EngineLabelKey, EngineLabelTiFlash) && hasLabel(labels, EngineRoleLabelKey, EngineRoleWrite);
 }
 
 bool labelFilterNoTiFlashWriteNode(const std::map<std::string, std::string> & labels)
 {
-    return hasLabel(labels, EngineLabelKey, EngineLabelTiFlash) &&
-        !hasLabel(labels, EngineRoleLabelKey, EngineRoleWrite);
+    return hasLabel(labels, EngineLabelKey, EngineLabelTiFlash) && !hasLabel(labels, EngineRoleLabelKey, EngineRoleWrite);
 }
 
 bool labelFilterAllTiFlashNode(const std::map<std::string, std::string> & labels)

--- a/src/test/batch_coprocessor_test.cc
+++ b/src/test/batch_coprocessor_test.cc
@@ -144,6 +144,7 @@ TEST_F(TestBatchCoprocessor, BuildTask1)
             table_ids,
             ranges_for_each_physical_table,
             kv::StoreType::TiKV,
+            kv::labelFilterNoTiFlashWriteNode,
             log);
 
         // Only 1 store, so only 1 batch cop task is generated
@@ -190,6 +191,7 @@ TEST_F(TestBatchCoprocessor, BuildTaskPartitionTable)
         table_ids,
         ranges_for_each_physical_table,
         kv::StoreType::TiKV,
+        kv::labelFilterNoTiFlashWriteNode,
         log);
 
     // Only 1 store, so only 1 batch cop task is generated
@@ -260,6 +262,7 @@ TEST_F(TestBatchCoprocessor, BuildTask3)
             table_ids,
             ranges_for_each_physical_table,
             kv::StoreType::TiKV,
+            kv::labelFilterNoTiFlashWriteNode,
             log);
 
         // Only 1 store, so only 1 batch cop task is generated

--- a/src/test/batch_coprocessor_test.cc
+++ b/src/test/batch_coprocessor_test.cc
@@ -226,7 +226,7 @@ TEST_F(TestBatchCoprocessor, BuildTaskPartitionTable)
     EXPECT_EQ(batch_cop_task->table_regions[1].region_infos[1].partition_index, 1);
     EXPECT_KEY_RANGES_EQ(batch_cop_task->table_regions[1].region_infos[1].ranges, expect_ranges3);
 }
- 
+
 TEST_F(TestBatchCoprocessor, BuildTask3)
 {
     Backoffer bo(copBuildTaskMaxBackoff);

--- a/src/test/coprocessor_test.cc
+++ b/src/test/coprocessor_test.cc
@@ -76,4 +76,4 @@ TEST_F(TestCoprocessor, testBuildTask1)
     ASSERT_EQ(has_next, false);
 }
 
-} // namespace pingcap
+} // namespace pingcap::tests

--- a/src/test/io_or_region_error_get_test.cc
+++ b/src/test/io_or_region_error_get_test.cc
@@ -55,4 +55,4 @@ INSTANTIATE_TEST_SUITE_P(RunGetWithInjectedErr,
                          testing::Values(std::make_tuple("server-is-busy", "2*return()"),
                                          std::make_tuple("io-timeout", "8*return()")));
 
-} // namespace
+} // namespace pingcap::tests

--- a/src/test/lock_resolve_test.cc
+++ b/src/test/lock_resolve_test.cc
@@ -120,4 +120,4 @@ TEST_F(TestWithLockResolve, testResolveLockGet)
     }
 }
 
-} // namespace
+} // namespace pingcap::tests

--- a/src/test/region_split_test.cc
+++ b/src/test/region_split_test.cc
@@ -116,4 +116,4 @@ TEST_F(TestWithMockKVRegionSplit, testSplitRegionScan)
     ASSERT_EQ(answer, 6);
 }
 
-} // namespace
+} // namespace pingcap::tests


### PR DESCRIPTION
There are two paths that need consider `<engine_role, write>`
1. copTask: tiflash's remote read use cop task. So need to consider in `ResponseIter`
2. batchCopTask: in disaggregated tiflash mode, MPP need to build batchCopTask.

Changes: Use `label_filter` to choose <engine_role, write> or not.
1. ResponseIter: This is for copTask path(remote read)
2. buildBatchCopTasks: The following all need to consider `label_filter`
  2.1. getRPCContext
  2.2. getAllValidTiFlashStores
  2.3. getAllTiFlashStores
  2.4. selectTiFlashPeers