### PR TITLE
Fix build with latest kvproto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 [submodule "third_party/libfiu"]
 	path = third_party/libfiu
 	url = https://github.com/albertito/libfiu.git
-[submodule "contrib/abseil-cpp"]
+[submodule "third_party/abseil-cpp"]
 	path = third_party/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/libfiu"]
 	path = third_party/libfiu
 	url = https://github.com/albertito/libfiu.git
+[submodule "contrib/abseil-cpp"]
+	path = third_party/abseil-cpp
+	url = https://github.com/abseil/abseil-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ if (NOT Protobuf_INCLUDE_DIR)
     include (cmake/find_protobuf.cmake)
 endif ()
 
+if (NOT ABSL_ROOT_DIR)
+    include (cmake/find_abseil-cpp.cmake)
+endif ()
+
 if (NOT gRPC_FOUND)
     include (cmake/find_grpc.cmake)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,6 @@ if (NOT Protobuf_INCLUDE_DIR)
     include (cmake/find_protobuf.cmake)
 endif ()
 
-if (NOT ABSL_ROOT_DIR)
-    include (cmake/find_abseil-cpp.cmake)
-endif ()
-
 if (NOT gRPC_FOUND)
     include (cmake/find_grpc.cmake)
 endif ()

--- a/cmake/find_abseil-cpp.cmake
+++ b/cmake/find_abseil-cpp.cmake
@@ -1,0 +1,2 @@
+find_package(absl REQUIRED)
+message(STATUS "Using absl: dir=${absl_DIR}, version=${absl_VERSION}")

--- a/cmake/find_abseil-cpp.cmake
+++ b/cmake/find_abseil-cpp.cmake
@@ -1,2 +1,0 @@
-find_package(absl REQUIRED)
-message(STATUS "Using absl: dir=${absl_DIR}, version=${absl_VERSION}")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-add_subdirectory(abseil-cpp-cmake)
+if (NOT ABSL_ROOT_DIR)
+    add_subdirectory(abseil-cpp-cmake)
+endif()
 
 if (NOT KVPROTO_FOUND)
     add_subdirectory (kvproto/cpp)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_subdirectory(abseil-cpp-cmake)
+
 if (NOT KVPROTO_FOUND)
     add_subdirectory (kvproto/cpp)
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,3 @@
-if (NOT ABSL_ROOT_DIR)
-    include (cmake/find_abseil-cpp.cmake)
-endif ()
 
 if (NOT KVPROTO_FOUND)
     add_subdirectory (kvproto/cpp)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -7,6 +7,10 @@ if (USE_INTERNAL_GTEST_LIBRARY AND ENABLE_TESTS)
     add_subdirectory (googletest)
 endif()
 
+if (NOT ABSL_ROOT_DIR)
+    include (cmake/find_abseil-cpp.cmake)
+endif ()
+
 set(fiu_include_dirs libfiu/libfiu)
 list(APPEND fiu_sources libfiu/libfiu/fiu.c)
 list(APPEND fiu_sources libfiu/libfiu/fiu-rc.c)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT ABSL_ROOT_DIR)
+    include (cmake/find_abseil-cpp.cmake)
+endif ()
+
 if (NOT KVPROTO_FOUND)
     add_subdirectory (kvproto/cpp)
 endif()
@@ -6,10 +10,6 @@ if (USE_INTERNAL_GTEST_LIBRARY AND ENABLE_TESTS)
     set(GTEST_INSTALL OFF)
     add_subdirectory (googletest)
 endif()
-
-if (NOT ABSL_ROOT_DIR)
-    include (cmake/find_abseil-cpp.cmake)
-endif ()
 
 set(fiu_include_dirs libfiu/libfiu)
 list(APPEND fiu_sources libfiu/libfiu/fiu.c)

--- a/third_party/abseil-cpp-cmake/CMakeLists.txt
+++ b/third_party/abseil-cpp-cmake/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(ABSL_ROOT_DIR "${TiFlash_SOURCE_DIR}/contrib/abseil-cpp")
+set(ABSL_ROOT_DIR "${ABSL_ROOT_DIR}" PARENT_SCOPE)
+if(NOT EXISTS "${ABSL_ROOT_DIR}/CMakeLists.txt")
+  message(FATAL_ERROR " submodule third_party/abseil-cpp is missing. To fix try run: \n git submodule update --init --recursive")
+endif()
+set(BUILD_TESTING OFF)
+set(ABSL_PROPAGATE_CXX_STD ON)
+
+no_warning(deprecated-builtins)
+add_subdirectory("${ABSL_ROOT_DIR}" "${TiFlash_BINARY_DIR}/contrib/abseil-cpp")
+
+add_library(abseil_swiss_tables INTERFACE)
+set_target_properties(abseil_swiss_tables PROPERTIES INTERFACE_COMPILE_OPTIONS "-Wno-array-parameter")
+
+target_link_libraries(abseil_swiss_tables INTERFACE
+  absl::flat_hash_map
+  absl::flat_hash_set
+)
+
+get_target_property(FLAT_HASH_MAP_INCLUDE_DIR absl::flat_hash_map INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories (abseil_swiss_tables SYSTEM BEFORE INTERFACE ${FLAT_HASH_MAP_INCLUDE_DIR})
+
+get_target_property(FLAT_HASH_SET_INCLUDE_DIR absl::flat_hash_set INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories (abseil_swiss_tables SYSTEM BEFORE INTERFACE ${FLAT_HASH_SET_INCLUDE_DIR})

--- a/third_party/abseil-cpp-cmake/CMakeLists.txt
+++ b/third_party/abseil-cpp-cmake/CMakeLists.txt
@@ -21,3 +21,5 @@ target_include_directories (abseil_swiss_tables SYSTEM BEFORE INTERFACE ${FLAT_H
 
 get_target_property(FLAT_HASH_SET_INCLUDE_DIR absl::flat_hash_set INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories (abseil_swiss_tables SYSTEM BEFORE INTERFACE ${FLAT_HASH_SET_INCLUDE_DIR})
+
+message(STATUS "Using absl: dir=${ABSL_ROOT_DIR}")

--- a/third_party/abseil-cpp-cmake/CMakeLists.txt
+++ b/third_party/abseil-cpp-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(ABSL_ROOT_DIR "${TiFlash_SOURCE_DIR}/contrib/abseil-cpp")
+set(ABSL_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../abseil-cpp")
 set(ABSL_ROOT_DIR "${ABSL_ROOT_DIR}" PARENT_SCOPE)
 if(NOT EXISTS "${ABSL_ROOT_DIR}/CMakeLists.txt")
   message(FATAL_ERROR " submodule third_party/abseil-cpp is missing. To fix try run: \n git submodule update --init --recursive")
@@ -6,8 +6,7 @@ endif()
 set(BUILD_TESTING OFF)
 set(ABSL_PROPAGATE_CXX_STD ON)
 
-no_warning(deprecated-builtins)
-add_subdirectory("${ABSL_ROOT_DIR}" "${TiFlash_BINARY_DIR}/contrib/abseil-cpp")
+add_subdirectory("${ABSL_ROOT_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/../abseil-cpp")
 
 add_library(abseil_swiss_tables INTERFACE)
 set_target_properties(abseil_swiss_tables PROPERTIES INTERFACE_COMPILE_OPTIONS "-Wno-array-parameter")


### PR DESCRIPTION
This is a workaround for building client-c with the latest kvproto. This embed abseil-cpp as a submodule to fix the build.

A better solution is to install abseil-cpp in docker, or replace the build docker by github CI like [pingcap/kvproto](https://github.com/pingcap/kvproto/blob/master/.github/workflows/cpp-test.yaml). But we could do it later.

