### PR TITLE
support mpp_prober to detect tiflash aliveness

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -3,9 +3,11 @@ clang-format -i ./include/pingcap/kv/*.h
 clang-format -i ./include/pingcap/coprocessor/*.h
 clang-format -i ./include/pingcap/kv/internal/*.h
 clang-format -i ./include/pingcap/pd/*.h
+clang-format -i ./include/pingcap/common/*.h
 clang-format -i ./include/pingcap/*.h
 clang-format -i ./src/kv/*.cc
 clang-format -i ./src/coprocessor/*.cc
 clang-format -i ./src/pd/*.cc
+clang-format -i ./src/common/*.cc
 clang-format -i ./src/test/*.cc
 clang-format -i ./src/test/*.h

--- a/include/pingcap/common/FixedThreadPool.h
+++ b/include/pingcap/common/FixedThreadPool.h
@@ -1,32 +1,41 @@
 #pragma once
 
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
 #include <thread>
 #include <vector>
-#include <functional>
 
 namespace pingcap
 {
 namespace common
 {
 
-class ThreadPool
+class FixedThreadPool
 {
 public:
-    explicit ThreadPool(size_t num_) : num(num_) {}
-    ~ThreadPool();
+    using Task = std::function<void()>;
+    explicit FixedThreadPool(size_t num_)
+        : num(num_)
+        , stopped(false) {}
+    ~FixedThreadPool() {}
 
-    void start() {}
+    void start();
 
-    template<typename F>
-    void enqueue(F f) {}
+    void enqueue(const Task & task);
 
-    void stop() {}
-
-    void wait() {}
+    void stop();
 
 private:
+    void loop();
+
     size_t num;
+    bool stopped;
     std::vector<std::thread> threads;
+    std::queue<Task> tasks;
+    std::mutex mu;
+    std::condition_variable cond;
 };
 
 } // namespace common

--- a/include/pingcap/common/FixedThreadPool.h
+++ b/include/pingcap/common/FixedThreadPool.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <thread>
+#include <vector>
+#include <functional>
+
+namespace pingcap
+{
+namespace common
+{
+
+class ThreadPool
+{
+public:
+    explicit ThreadPool(size_t num_) : num(num_) {}
+    ~ThreadPool();
+
+    void start() {}
+
+    template<typename F>
+    void enqueue(F f) {}
+
+    void stop() {}
+
+    void wait() {}
+
+private:
+    size_t num;
+    std::vector<std::thread> threads;
+};
+
+} // namespace common
+} // namespace pingcap

--- a/include/pingcap/common/FixedThreadPool.h
+++ b/include/pingcap/common/FixedThreadPool.h
@@ -18,7 +18,8 @@ public:
     using Task = std::function<void()>;
     explicit FixedThreadPool(size_t num_)
         : num(num_)
-        , stopped(false) {}
+        , stopped(false)
+    {}
     ~FixedThreadPool() = default;
 
     void start();

--- a/include/pingcap/common/FixedThreadPool.h
+++ b/include/pingcap/common/FixedThreadPool.h
@@ -19,7 +19,7 @@ public:
     explicit FixedThreadPool(size_t num_)
         : num(num_)
         , stopped(false) {}
-    ~FixedThreadPool() {}
+    ~FixedThreadPool() = default;
 
     void start();
 

--- a/include/pingcap/common/MPPProber.h
+++ b/include/pingcap/common/MPPProber.h
@@ -4,9 +4,9 @@
 #include <pingcap/kv/Rpc.h>
 
 #include <chrono>
+#include <mutex>
 #include <string>
 #include <unordered_map>
-#include <mutex>
 
 
 namespace pingcap
@@ -43,7 +43,8 @@ struct ProbeState
         , log(&Logger::get("pingcap.ProbeState"))
         , recovery_timepoint(INVALID_TIME_POINT)
         , last_lookup_timepoint(INVALID_TIME_POINT)
-        , last_detect_timepoint(INVALID_TIME_POINT) {}
+        , last_detect_timepoint(INVALID_TIME_POINT)
+    {}
 
     std::string store_addr;
     pingcap::kv::Cluster * cluster;
@@ -65,7 +66,8 @@ public:
         , detect_period(DETECT_PERIOD)
         , detect_rpc_timeout(DETECT_RPC_TIMEOUT)
         , log(&Logger::get("pingcap.MPPProber"))
-        , stopped(false) {}
+        , stopped(false)
+    {}
 
     void run();
     void stop();
@@ -80,7 +82,7 @@ private:
 
     void scan();
     void detect();
-    
+
     pingcap::kv::Cluster * cluster;
     std::chrono::seconds scan_interval;
     std::chrono::seconds detect_period;

--- a/include/pingcap/common/MPPProber.h
+++ b/include/pingcap/common/MPPProber.h
@@ -29,7 +29,7 @@ static constexpr size_t DETECT_RPC_TIMEOUT = 2;
 inline std::chrono::seconds getElapsed(const TimePoint & ago)
 {
     auto now = std::chrono::steady_clock::now();
-    return std::chrono::duration_cast<std::chrono::seconds>(ago - now);
+    return std::chrono::duration_cast<std::chrono::seconds>(now - ago);
 }
 
 

--- a/include/pingcap/common/MPPProber.h
+++ b/include/pingcap/common/MPPProber.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <pingcap/Log.h>
+#include <pingcap/kv/Rpc.h>
+
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <mutex>
+
+namespace pingcap
+{
+namespace common
+{
+
+using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+static constexpr TimePoint INVALID_TIME_POINT = std::chrono::steady_clock::time_point::max();
+static auto MAX_RECOVERY_TIME_LIMIT = std::chrono::minutes(15);
+static auto MAX_OBSOLET_TIME_LIMIT = std::chrono::hours(1);
+
+bool detectStore(kv::RpcClientPtr & rpc_client, const std::string & store_addr, int rpc_timeout, Logger * log);
+
+struct ProbeState
+{
+    std::mutex state_lock;
+    kv::RpcClientPtr rpc_client;
+    std::string store_addr;
+    TimePoint recovery_time;
+    TimePoint last_lookup_time;
+    TimePoint last_detect_time;
+    Logger * log;
+
+    void detectAndUpdateState(size_t detect_period, size_t detect_rpc_timeout);
+};
+
+class MPPProber
+{
+public:
+    MPPProber() : log(&Logger::get("pingcap.MPPProber")) {}
+
+    void run();
+
+    bool isRecovery(const std::string & store_addr);
+    bool detectStore(const std::string & store_addr);
+
+private:
+    using FailedStoreMap = std::unordered_map<std::string, std::shared_ptr<ProbeState>>;
+    static const int MIN_SCAN_INTERVAL = 5;
+
+    void scan();
+    void detect();
+    
+    Logger * log;
+    FailedStoreMap failed_stores;
+    std::mutex store_lock;
+    int scan_interval;
+    size_t detect_period;
+    size_t detect_rpc_timeout;
+};
+} // namespace common
+} // namespace pingcap

--- a/include/pingcap/common/MPPProber.h
+++ b/include/pingcap/common/MPPProber.h
@@ -8,27 +8,43 @@
 #include <unordered_map>
 #include <mutex>
 
+
 namespace pingcap
 {
+namespace kv
+{
+struct Cluster;
+} // namespace kv
 namespace common
 {
 
 using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
 static constexpr TimePoint INVALID_TIME_POINT = std::chrono::steady_clock::time_point::max();
-static auto MAX_RECOVERY_TIME_LIMIT = std::chrono::minutes(15);
-static auto MAX_OBSOLET_TIME_LIMIT = std::chrono::hours(1);
+static constexpr auto MAX_RECOVERY_TIME_LIMIT = std::chrono::minutes(15);
+static constexpr auto MAX_OBSOLET_TIME_LIMIT = std::chrono::hours(1);
+static constexpr size_t SCAN_INTERVAL = 1; // scan per 1s.
+static constexpr size_t DETECT_PERIOD = 3; // do real alive rpc per 3s
+static constexpr size_t DETECT_RPC_TIMEOUT = 2;
 
 bool detectStore(kv::RpcClientPtr & rpc_client, const std::string & store_addr, int rpc_timeout, Logger * log);
 
 struct ProbeState
 {
-    std::mutex state_lock;
-    kv::RpcClientPtr rpc_client;
+    ProbeState(const std::string & store_addr_, pingcap::kv::Cluster * cluster_)
+        : store_addr(store_addr_)
+        , cluster(cluster_)
+        , log(&Logger::get("pingcap.ProbeState"))
+        , recovery_timepoint(INVALID_TIME_POINT)
+        , last_lookup_timepoint(INVALID_TIME_POINT)
+        , last_detect_timepoint(INVALID_TIME_POINT) {}
+
     std::string store_addr;
-    TimePoint recovery_time;
-    TimePoint last_lookup_time;
-    TimePoint last_detect_time;
+    pingcap::kv::Cluster * cluster;
     Logger * log;
+    TimePoint recovery_timepoint;
+    TimePoint last_lookup_timepoint;
+    TimePoint last_detect_timepoint;
+    std::mutex state_lock;
 
     void detectAndUpdateState(size_t detect_period, size_t detect_rpc_timeout);
 };
@@ -36,12 +52,17 @@ struct ProbeState
 class MPPProber
 {
 public:
-    MPPProber() : log(&Logger::get("pingcap.MPPProber")) {}
+    explicit MPPProber(pingcap::kv::Cluster * cluster_)
+        : cluster(cluster_)
+        , scan_interval(SCAN_INTERVAL)
+        , detect_period(DETECT_PERIOD)
+        , detect_rpc_timeout(DETECT_RPC_TIMEOUT)
+        , log(&Logger::get("pingcap.MPPProber")) {}
 
     void run();
 
-    bool isRecovery(const std::string & store_addr);
-    bool detectStore(const std::string & store_addr);
+    bool isRecovery(const std::string & store_addr, size_t recovery_ttl);
+    void add(const std::string & store_addr);
 
 private:
     using FailedStoreMap = std::unordered_map<std::string, std::shared_ptr<ProbeState>>;
@@ -50,12 +71,13 @@ private:
     void scan();
     void detect();
     
+    pingcap::kv::Cluster * cluster;
+    size_t scan_interval;
+    size_t detect_period;
+    size_t detect_rpc_timeout;
     Logger * log;
     FailedStoreMap failed_stores;
     std::mutex store_lock;
-    int scan_interval;
-    size_t detect_period;
-    size_t detect_rpc_timeout;
 };
 } // namespace common
 } // namespace pingcap

--- a/include/pingcap/common/MPPProber.h
+++ b/include/pingcap/common/MPPProber.h
@@ -70,7 +70,9 @@ public:
     void run();
     void stop();
 
+    // Return true is this store is alive, false if dead.
     bool isRecovery(const std::string & store_addr, const std::chrono::seconds & recovery_ttl);
+    // Tag store as dead.
     void add(const std::string & store_addr);
 
 private:

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <pingcap/Config.h>
 #include <pingcap/common/FixedThreadPool.h>
 #include <pingcap/common/MPPProber.h>
-#include <pingcap/Config.h>
 #include <pingcap/kv/LockResolver.h>
 #include <pingcap/kv/Rpc.h>
 #include <pingcap/pd/Client.h>

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -64,6 +64,7 @@ struct Cluster
     // (e.g. background threads) that cluster object holds so as to exit elegantly.
     ~Cluster()
     {
+        mpp_prober->stop();
         thread_pool->stop();
     }
 

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -29,14 +29,14 @@ struct Cluster
 
     ::kvrpcpb::APIVersion api_version = ::kvrpcpb::APIVersion::V1;
 
-    std::unique_ptr<common::ThreadPool> thread_pool;
+    std::unique_ptr<pingcap::common::FixedThreadPool> thread_pool;
     std::unique_ptr<common::MPPProber> mpp_prober;
 
     Cluster()
         : pd_client(std::make_shared<pd::MockPDClient>())
         , rpc_client(std::make_unique<RpcClient>())
-        , thread_pool(std::make_unique<common::ThreadPool>(1))
-        , mpp_prober(std::make_unique<common::MPPProber>())
+        , thread_pool(std::make_unique<pingcap::common::FixedThreadPool>(1))
+        , mpp_prober(std::make_unique<common::MPPProber>(this))
     {
         startBackgourndTasks();
     }
@@ -48,8 +48,8 @@ struct Cluster
         , oracle(std::make_unique<pd::Oracle>(pd_client, std::chrono::milliseconds(oracle_update_interval)))
         , lock_resolver(std::make_unique<LockResolver>(this))
         , api_version(config.api_version)
-        , thread_pool(std::make_unique<common::ThreadPool>(1))
-        , mpp_prober(std::make_unique<common::MPPProber>())
+        , thread_pool(std::make_unique<pingcap::common::FixedThreadPool>(1))
+        , mpp_prober(std::make_unique<common::MPPProber>(this))
     {
         startBackgourndTasks();
     }

--- a/include/pingcap/kv/internal/type_traits.h
+++ b/include/pingcap/kv/internal/type_traits.h
@@ -46,6 +46,7 @@ PINGCAP_DEFINE_TRAITS(kvrpcpb, CheckSecondaryLocks, KvCheckSecondaryLocks)
 PINGCAP_DEFINE_TRAITS(coprocessor, , Coprocessor)
 PINGCAP_DEFINE_TRAITS(mpp, DispatchTask, DispatchMPPTask)
 PINGCAP_DEFINE_TRAITS(mpp, CancelTask, CancelMPPTask)
+PINGCAP_DEFINE_TRAITS(mpp, IsAlive, IsAlive)
 
 // streaming trait for BatchRequest
 template <>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ list(APPEND kvClient_sources kv/Scanner.cc)
 list(APPEND kvClient_sources pd/Client.cc)
 list(APPEND kvClient_sources coprocessor/Client.cc)
 list(APPEND kvClient_sources RedactHelpers.cc)
+list(APPEND kvClient_sources common/FixedThreadPool.cc)
+list(APPEND kvClient_sources common/MPPProber.cc)
 
 set(kvClient_INCLUDE_DIR ${kvClient_SOURCE_DIR}/include)
 

--- a/src/common/FixedThreadPool.cc
+++ b/src/common/FixedThreadPool.cc
@@ -1,0 +1,59 @@
+#include <pingcap/common/FixedThreadPool.h>
+
+namespace pingcap
+{
+namespace common
+{
+
+void FixedThreadPool::start()
+{
+    for (size_t i = 0; i < num; ++i)
+    {
+        threads.push_back(std::thread(&FixedThreadPool::loop, this));
+    }
+}
+
+void FixedThreadPool::loop()
+{
+    Task task;
+    while (true)
+    {
+        std::unique_lock<std::mutex> lock(mu);
+        cond.wait(lock, [this] {
+                return !tasks.empty() || stopped;
+        });
+
+        if (stopped)
+            return;
+
+        task = tasks.front();
+        tasks.pop();
+    }
+    task();
+}
+
+void FixedThreadPool::enqueue(const Task & task)
+{
+    {
+        std::unique_lock<std::mutex> lock(mu);
+        tasks.push(task);
+    }
+    cond.notify_one();
+}
+
+void FixedThreadPool::stop()
+{
+    {
+        std::unique_lock<std::mutex> lock(mu);
+        stopped = true;
+    }
+    cond.notify_all();
+    for (auto & thr : threads)
+    {
+        thr.join();
+    }
+    threads.clear();
+}
+
+} // namespace common
+} // namespace pingcap

--- a/src/common/FixedThreadPool.cc
+++ b/src/common/FixedThreadPool.cc
@@ -15,21 +15,23 @@ void FixedThreadPool::start()
 
 void FixedThreadPool::loop()
 {
-    Task task;
     while (true)
     {
-        std::unique_lock<std::mutex> lock(mu);
-        cond.wait(lock, [this] {
-                return !tasks.empty() || stopped;
-        });
+        Task task;
+        {
+            std::unique_lock<std::mutex> lock(mu);
+            cond.wait(lock, [this] {
+                    return !tasks.empty() || stopped;
+                    });
 
-        if (stopped)
-            return;
+            if (stopped)
+                return;
 
-        task = tasks.front();
-        tasks.pop();
+            task = tasks.front();
+            tasks.pop();
+        }
+        task();
     }
-    task();
 }
 
 void FixedThreadPool::enqueue(const Task & task)

--- a/src/common/FixedThreadPool.cc
+++ b/src/common/FixedThreadPool.cc
@@ -21,8 +21,8 @@ void FixedThreadPool::loop()
         {
             std::unique_lock<std::mutex> lock(mu);
             cond.wait(lock, [this] {
-                    return !tasks.empty() || stopped;
-                    });
+                return !tasks.empty() || stopped;
+            });
 
             if (stopped)
                 return;

--- a/src/common/MPPProber.cc
+++ b/src/common/MPPProber.cc
@@ -119,7 +119,6 @@ void ProbeState::detectAndUpdateState(const std::chrono::seconds & detect_period
 
 bool detectStore(kv::RpcClientPtr & rpc_client, const std::string & store_addr, int rpc_timeout, Logger * log)
 {
-    // auto req = std::make_shared<::mpp::IsAliveRequest>;
     kv::RpcCall<::mpp::IsAliveRequest> rpc(std::make_shared<::mpp::IsAliveRequest>());
     try
     {

--- a/src/common/MPPProber.cc
+++ b/src/common/MPPProber.cc
@@ -1,8 +1,9 @@
+#include <kvproto/mpp.pb.h>
+#include <pingcap/Exception.h>
 #include <pingcap/common/MPPProber.h>
 #include <pingcap/kv/Cluster.h>
-#include <pingcap/Exception.h>
+
 #include <thread>
-#include <kvproto/mpp.pb.h>
 
 namespace pingcap
 {
@@ -22,8 +23,7 @@ bool MPPProber::isRecovery(const std::string & store_addr, const std::chrono::se
 
     {
         std::lock_guard<std::mutex> lock(iter->second->state_lock);
-        return iter->second->recovery_timepoint != INVALID_TIME_POINT &&
-            getElapsed(iter->second->recovery_timepoint) > recovery_ttl;
+        return iter->second->recovery_timepoint != INVALID_TIME_POINT && getElapsed(iter->second->recovery_timepoint) > recovery_ttl;
     }
 }
 
@@ -71,7 +71,7 @@ void MPPProber::scan()
             continue;
 
         ele.second->detectAndUpdateState(detect_period, detect_rpc_timeout);
-        
+
         const auto & recovery_timepoint = ele.second->recovery_timepoint;
         if (recovery_timepoint != INVALID_TIME_POINT)
         {

--- a/src/common/MPPProber.cc
+++ b/src/common/MPPProber.cc
@@ -104,8 +104,8 @@ void ProbeState::detectAndUpdateState(const std::chrono::seconds & detect_period
     if (getElapsed(last_detect_timepoint) < detect_period)
         return;
 
-    bool dead_store = detectStore(cluster->rpc_client, store_addr, detect_rpc_timeout, log);
-    if (dead_store)
+    bool is_alive = detectStore(cluster->rpc_client, store_addr, detect_rpc_timeout, log);
+    if (!is_alive)
     {
         log->debug("got dead store: " + store_addr);
         recovery_timepoint = INVALID_TIME_POINT;

--- a/src/common/MPPProber.cc
+++ b/src/common/MPPProber.cc
@@ -1,0 +1,103 @@
+#include <pingcap/common/MPPProber.h>
+#include <pingcap/Exception.h>
+#include <thread>
+#include <kvproto/mpp.pb.h>
+
+namespace pingcap
+{
+namespace common
+{
+
+void MPPProber::run()
+{
+    while (true)
+    {
+        if (scan_interval <= MIN_SCAN_INTERVAL)
+        {
+            throw Exception("scan_interval too small", ErrorCodes::LogicalError);
+        }
+        std::this_thread::sleep_for(scan_interval);
+
+        scan();
+    }
+}
+
+void MPPProber::scan()
+{
+    FailedStoreMap copy_failed_stores;
+    {
+        std::lock_guard<std::mutex> guard(store_lock);
+        copy_failed_stores = failed_stores;
+    }
+    std::vector<std::string> recovery_stores;
+    recovery_stores.reserve(copy_failed_stores.size());
+
+    for (const auto & ele : copy_failed_stores)
+    {
+        if (!ele.second->state_lock.try_lock())
+            continue;
+
+        ele.second->detectAndUpdateState(detect_period, detect_rpc_timeout);
+        
+        auto now = std::chrono::steady_clock::now();
+        const auto & recovery_timepoint = ele.second->recovery_time;
+        if (recovery_timepoint != INVALID_TIME_POINT)
+        {
+            // Means this store is now alive.
+            auto recovery_elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - recovery_timepoint).count();
+            if (recovery_elapsed > std::chrono::duration_cast<std::chrono::seconds>(MAX_RECOVERY_TIME_LIMIT))
+            {
+                recovery_stores.push_back(ele.first);
+            }
+        }
+        else if (ele.second.last_lookup_time > std::chrono::duration_cast<std::chrono::seconds>(MAX_OBSOLET_TIME))
+        {
+            recovery_stores.push_back(ele.first);
+        }
+        ele.second->state_lock.unlock();
+    }
+
+    {
+        std::lock_guard<std::mutex> guard(store_lock);
+        for (const auto & store : recovery_stores)
+        {
+            failed_stores.erase(store);
+        }
+    }
+}
+
+void ProbeState::detectAndUpdateState(size_t detect_period, size_t detect_rpc_timeout)
+{
+    bool dead_store = detectStore(rpc_client, store_addr, detect_rpc_timeout, log);
+    if (dead_store)
+    {
+        log->debug("got dead store: " + store_addr);
+        recovery_time = INVALID_TIME_POINT;
+    }
+    else if (recovery_time == INVALID_TIME_POINT)
+    {
+        // Alive store, and first recovery, set its recovery time.
+        recovery_time = std::chrono::steady_clock::now();
+    }
+}
+
+bool detectStore(kv::RpcClientPtr & rpc_client, const std::string & store_addr, int rpc_timeout, Logger * log)
+{
+    mpp::IsAliveRequest req;
+    kv::RpcCall<mpp::IsAliveRequest> rpc(req);
+    try
+    {
+        rpc_client->sendRequest(store_addr, rpc, rpc_timeout, kv::GRPCMetaData{});
+    }
+    catch (const Exception & e)
+    {
+        log->warning("detect failed: " + store_addr + " error: ", e.message());
+        return false;
+    }
+
+    const auto & resp = rpc.getResp();
+    return resp->available();
+}
+
+} // namespace common
+} // namespace pingcap

--- a/src/common/MPPProber.cc
+++ b/src/common/MPPProber.cc
@@ -1,4 +1,5 @@
 #include <pingcap/common/MPPProber.h>
+#include <pingcap/kv/Cluster.h>
 #include <pingcap/Exception.h>
 #include <thread>
 #include <kvproto/mpp.pb.h>
@@ -8,15 +9,48 @@ namespace pingcap
 namespace common
 {
 
+bool MPPProber::isRecovery(const std::string & store_addr, size_t recovery_ttl)
+{
+    FailedStoreMap copy_failed_stores;
+    {
+        std::lock_guard<std::mutex> lock(store_lock);
+        copy_failed_stores = failed_stores;
+    }
+    auto iter = copy_failed_stores.find(store_addr);
+    if (iter == copy_failed_stores.end())
+        return true;
+
+    {
+        auto now = std::chrono::steady_clock::now();
+        std::lock_guard<std::mutex> lock(iter->second->state_lock);
+        auto recovery_elapsed = std::chrono::duration_cast<std::chrono::seconds>(iter->second->recovery_timepoint - now).count();
+        return iter->second->recovery_timepoint != INVALID_TIME_POINT && recovery_elapsed > recovery_ttl;
+    }
+}
+
+void MPPProber::add(const std::string & store_addr)
+{
+    std::lock_guard<std::mutex> lock(store_lock);
+    auto iter = failed_stores.find(store_addr);
+    if (iter == failed_stores.end())
+    {
+        failed_stores[store_addr] = std::make_shared<ProbeState>(store_addr, cluster);
+    }
+    else
+    {
+        iter->second->last_lookup_timepoint = std::chrono::steady_clock::now();
+    }
+}
+
 void MPPProber::run()
 {
     while (true)
     {
-        if (scan_interval <= MIN_SCAN_INTERVAL)
+        if (scan_interval < 1)
         {
-            throw Exception("scan_interval too small", ErrorCodes::LogicalError);
+            throw Exception("scan_interval is invalid", ErrorCodes::LogicalError);
         }
-        std::this_thread::sleep_for(scan_interval);
+        std::this_thread::sleep_for(std::chrono::seconds(scan_interval));
 
         scan();
     }
@@ -40,19 +74,22 @@ void MPPProber::scan()
         ele.second->detectAndUpdateState(detect_period, detect_rpc_timeout);
         
         auto now = std::chrono::steady_clock::now();
-        const auto & recovery_timepoint = ele.second->recovery_time;
+        const auto & recovery_timepoint = ele.second->recovery_timepoint;
         if (recovery_timepoint != INVALID_TIME_POINT)
         {
             // Means this store is now alive.
-            auto recovery_elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - recovery_timepoint).count();
+            auto recovery_elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - recovery_timepoint);
             if (recovery_elapsed > std::chrono::duration_cast<std::chrono::seconds>(MAX_RECOVERY_TIME_LIMIT))
             {
                 recovery_stores.push_back(ele.first);
             }
         }
-        else if (ele.second.last_lookup_time > std::chrono::duration_cast<std::chrono::seconds>(MAX_OBSOLET_TIME))
+        else
         {
-            recovery_stores.push_back(ele.first);
+            // Store is dead, we want to check if this store has not used for MAX_OBSOLET_TIME.
+            auto lookup_elapsed = std::chrono::duration_cast<std::chrono::seconds>(ele.second->last_lookup_timepoint - now);
+            if (lookup_elapsed > std::chrono::duration_cast<std::chrono::seconds>(MAX_OBSOLET_TIME_LIMIT))
+                recovery_stores.push_back(ele.first);
         }
         ele.second->state_lock.unlock();
     }
@@ -68,23 +105,23 @@ void MPPProber::scan()
 
 void ProbeState::detectAndUpdateState(size_t detect_period, size_t detect_rpc_timeout)
 {
-    bool dead_store = detectStore(rpc_client, store_addr, detect_rpc_timeout, log);
+    bool dead_store = detectStore(cluster->rpc_client, store_addr, detect_rpc_timeout, log);
     if (dead_store)
     {
         log->debug("got dead store: " + store_addr);
-        recovery_time = INVALID_TIME_POINT;
+        recovery_timepoint = INVALID_TIME_POINT;
     }
-    else if (recovery_time == INVALID_TIME_POINT)
+    else if (recovery_timepoint == INVALID_TIME_POINT)
     {
         // Alive store, and first recovery, set its recovery time.
-        recovery_time = std::chrono::steady_clock::now();
+        recovery_timepoint = std::chrono::steady_clock::now();
     }
 }
 
 bool detectStore(kv::RpcClientPtr & rpc_client, const std::string & store_addr, int rpc_timeout, Logger * log)
 {
-    mpp::IsAliveRequest req;
-    kv::RpcCall<mpp::IsAliveRequest> rpc(req);
+    // auto req = std::make_shared<::mpp::IsAliveRequest>;
+    kv::RpcCall<::mpp::IsAliveRequest> rpc(std::make_shared<::mpp::IsAliveRequest>());
     try
     {
         rpc_client->sendRequest(store_addr, rpc, rpc_timeout, kv::GRPCMetaData{});

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -170,6 +170,9 @@ std::vector<BatchCopTask> balanceBatchCopTasks(kv::Cluster * cluster, kv::Region
         log->information(stores_to_str("before filter alive stores: ", tiflash_stores));
         auto alive_tiflash_stores = filterAliveStores(cluster, tiflash_stores, log);
         log->information(stores_to_str("after filter alive stores: ", alive_tiflash_stores));
+        if (alive_tiflash_stores.empty())
+            throw Exception("no alive tiflash, cannot dispatch BatchCopTask", ErrorCodes::CoprocessorError);
+
         for (const auto & store : alive_tiflash_stores)
         {
             auto store_id = store.first;

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -124,7 +124,10 @@ std::map<uint64_t, kv::Store> filterAliveStores(kv::Cluster * cluster, const std
             continue;
 
         if (!common::detectStore(cluster->rpc_client, ele.second.addr, /*rpc_timeout=*/2, log))
+        {
             cluster->mpp_prober->add(ele.second.addr);
+            continue;
+        }
 
         alive_stores.emplace(ele.first, ele.second);
     }

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -115,7 +115,23 @@ std::vector<LocationKeyRanges> splitKeyRangesByLocations(
     return res;
 }
 
-std::vector<BatchCopTask> balanceBatchCopTasks(kv::RegionCachePtr & cache, std::vector<BatchCopTask> && original_tasks, bool is_mpp, const kv::LabelFilter & label_filter, Poco::Logger * log)
+std::map<uint64_t, kv::Store> filterAliveStores(kv::Cluster * cluster, const std::map<uint64_t, kv::Store> & stores, Logger * log)
+{
+    std::map<uint64_t, kv::Store> alive_stores;
+    for (const auto & ele : stores)
+    {
+        if (!cluster->mpp_prober->isRecovery(ele.second.addr, /*mpp_fail_ttl=*/60))
+            continue;
+
+        if (!common::detectStore(cluster->rpc_client, ele.second.addr, /*rpc_timeout=*/2, log))
+            cluster->mpp_prober->add(ele.second.addr);
+
+        alive_stores.emplace(ele.first, ele.second);
+    }
+    return alive_stores;
+}
+
+std::vector<BatchCopTask> balanceBatchCopTasks(kv::Cluster * cluster, kv::RegionCachePtr & cache, std::vector<BatchCopTask> && original_tasks, bool is_mpp, const kv::LabelFilter & label_filter, Poco::Logger * log)
 {
     if (original_tasks.empty())
     {
@@ -144,19 +160,24 @@ std::vector<BatchCopTask> balanceBatchCopTasks(kv::RegionCachePtr & cache, std::
     }
     else
     {
-        // todo: 1. filter alive stores. 2. background get all stores.
+        auto stores_to_str = [](const std::string_view prefix, const std::map<uint64_t, kv::Store> & stores) -> std::string {
+            std::string msg(prefix);
+            for (const auto & ele : stores)
+                msg += " " + ele.second.addr;
+            return msg;
+        };
         auto tiflash_stores = cache->getAllTiFlashStores(label_filter, /*exclude_tombstone =*/true);
-        std::string log_msg = "all tiflash stores: ";
-        for (const auto & store : tiflash_stores)
+        log->information("before filter alive stores: ", tiflash_stores);
+        auto alive_tiflash_stores = filterAliveStores(cluster, tiflash_stores, log);
+        log->information("after filter alive stores: ", alive_tiflash_stores);
+        for (const auto & store : alive_tiflash_stores)
         {
             auto store_id = store.first;
             BatchCopTask new_batch_task;
             new_batch_task.store_addr = store.second.addr;
             new_batch_task.store_id = store_id;
             store_task_map[store_id] = new_batch_task;
-            log_msg += store.second.addr + "; ";
         }
-        log->information(log_msg);
     }
 
     std::map<uint64_t, std::map<std::string, RegionInfo>> store_candidate_region_map;
@@ -423,7 +444,7 @@ std::vector<BatchCopTask> buildBatchCopTasks(
         };
         if (log->getLevel() >= Poco::Message::PRIO_INFORMATION)
             log->information(tasks_to_str("Before region balance:", batch_cop_tasks));
-        batch_cop_tasks = details::balanceBatchCopTasks(cache, std::move(batch_cop_tasks), is_mpp, label_filter, log);
+        batch_cop_tasks = details::balanceBatchCopTasks(cluster, cache, std::move(batch_cop_tasks), is_mpp, label_filter, log);
         if (log->getLevel() >= Poco::Message::PRIO_INFORMATION)
             log->information(tasks_to_str("After region balance:", batch_cop_tasks));
         auto balance_end = std::chrono::steady_clock::now();

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -120,7 +120,7 @@ std::map<uint64_t, kv::Store> filterAliveStores(kv::Cluster * cluster, const std
     std::map<uint64_t, kv::Store> alive_stores;
     for (const auto & ele : stores)
     {
-        if (!cluster->mpp_prober->isRecovery(ele.second.addr, /*mpp_fail_ttl=*/60))
+        if (!cluster->mpp_prober->isRecovery(ele.second.addr, /*mpp_fail_ttl=*/std::chrono::seconds(60)))
             continue;
 
         if (!common::detectStore(cluster->rpc_client, ele.second.addr, /*rpc_timeout=*/2, log))
@@ -167,9 +167,9 @@ std::vector<BatchCopTask> balanceBatchCopTasks(kv::Cluster * cluster, kv::Region
             return msg;
         };
         auto tiflash_stores = cache->getAllTiFlashStores(label_filter, /*exclude_tombstone =*/true);
-        log->information("before filter alive stores: ", tiflash_stores);
+        log->information(stores_to_str("before filter alive stores: ", tiflash_stores));
         auto alive_tiflash_stores = filterAliveStores(cluster, tiflash_stores, log);
-        log->information("after filter alive stores: ", alive_tiflash_stores);
+        log->information(stores_to_str("after filter alive stores: ", alive_tiflash_stores));
         for (const auto & store : alive_tiflash_stores)
         {
             auto store_id = store.first;

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -26,5 +26,13 @@ void Cluster::splitRegion(const std::string & split_key)
     region_cache->getRegionByID(bo, RegionVerID(rr.id(), rr.region_epoch().conf_ver(), rr.region_epoch().version()));
 }
 
+void Cluster::startBackgourndTasks()
+{
+    thread_pool->start();
+    thread_pool->enqueue([this] {
+            this->mpp_prober->run();
+    });
+}
+
 } // namespace kv
 } // namespace pingcap

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -30,7 +30,7 @@ void Cluster::startBackgourndTasks()
 {
     thread_pool->start();
     thread_pool->enqueue([this] {
-            this->mpp_prober->run();
+        this->mpp_prober->run();
     });
 }
 

--- a/src/test/batch_coprocessor_test.cc
+++ b/src/test/batch_coprocessor_test.cc
@@ -139,7 +139,7 @@ TEST_F(TestBatchCoprocessor, BuildTask1)
         auto batch_cop_tasks = coprocessor::buildBatchCopTasks(
             bo,
             test_cluster.get(),
-            true,
+            /*is_mpp=*/false,
             is_partition_table,
             table_ids,
             ranges_for_each_physical_table,
@@ -186,7 +186,7 @@ TEST_F(TestBatchCoprocessor, BuildTaskPartitionTable)
     auto batch_cop_tasks = coprocessor::buildBatchCopTasks(
         bo,
         test_cluster.get(),
-        true,
+        /*is_mpp=*/false,
         is_partition_table,
         table_ids,
         ranges_for_each_physical_table,
@@ -257,7 +257,7 @@ TEST_F(TestBatchCoprocessor, BuildTask3)
         auto batch_cop_tasks = coprocessor::buildBatchCopTasks(
             bo,
             test_cluster.get(),
-            true,
+            /*is_mpp=*/false,
             is_partition_table,
             table_ids,
             ranges_for_each_physical_table,


### PR DESCRIPTION
Basically same as https://github.com/pingcap/tidb/blob/master/store/copr/mpp_probe.go

1. MPPProber record all failed stores, and will check if alive in background.
2. Caller first check if in MPPProber.failed_stores, if true, then ignore this failed store, otherwise send alive rpc to do real detect.
3. For now, thread pool only has one thread. Will add another background thread to refresh region cache later.
4. test case will be add in endless later, only manually test for now.