### PR TITLE
Update builder image to ubuntu 23.04

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:23.04
 
 RUN apt update -y \
  && apt install -y cmake build-essential \


### PR DESCRIPTION
Current builder image is using ubuntu 21.04 which is old and apt install will fail.