### PR TITLE
Refine include header && Fix compile warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ tags
 
 # vscode clangd cache
 .cache
+
+# JSON Compilation Database Format Specification
+# https://clang.llvm.org/docs/JSONCompilationDatabase.html
+compile_commands.json

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -38,7 +38,7 @@ struct Cluster
         , thread_pool(std::make_unique<pingcap::common::FixedThreadPool>(1))
         , mpp_prober(std::make_unique<common::MPPProber>(this))
     {
-        startBackgourndTasks();
+        startBackgroundTasks();
     }
 
     Cluster(const std::vector<std::string> & pd_addrs, const ClusterConfig & config)
@@ -51,7 +51,7 @@ struct Cluster
         , thread_pool(std::make_unique<pingcap::common::FixedThreadPool>(1))
         , mpp_prober(std::make_unique<common::MPPProber>(this))
     {
-        startBackgourndTasks();
+        startBackgroundTasks();
     }
 
     void update(const std::vector<std::string> & pd_addrs, const ClusterConfig & config) const
@@ -71,7 +71,7 @@ struct Cluster
     // Only used by Test and this is not safe !
     void splitRegion(const std::string & split_key);
 
-    void startBackgourndTasks();
+    void startBackgroundTasks();
 };
 
 struct MinCommitTSPushed

--- a/include/pingcap/pd/IClient.h
+++ b/include/pingcap/pd/IClient.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pingcap/Config.h>
+#include <pingcap/pd/Types.h>
 
 #include <string>
 #include <vector>
@@ -11,20 +12,11 @@
 #include <kvproto/pdpb.pb.h>
 #include <kvproto/resource_manager.pb.h>
 #pragma GCC diagnostic pop
-#include <pingcap/Config.h>
 
 namespace pingcap
 {
 namespace pd
 {
-using KeyspaceID = uint32_t;
-
-enum : KeyspaceID
-{
-    // The size of KeyspaceID allocated for PD is 3 bytes.
-    // The NullspaceID is preserved for TiDB API V1 compatibility.
-    NullspaceID = 0xffffffff,
-};
 
 class IClient
 {

--- a/include/pingcap/pd/Types.h
+++ b/include/pingcap/pd/Types.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace pingcap::pd
+{
+
+using KeyspaceID = uint32_t;
+
+enum : KeyspaceID
+{
+    // The size of KeyspaceID allocated for PD is 3 bytes.
+    // The NullspaceID is preserved for TiDB API V1 compatibility.
+    NullspaceID = 0xffffffff,
+};
+
+} // namespace pingcap::pd

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -13,21 +13,22 @@ void Cluster::splitRegion(const std::string & split_key)
     auto loc = region_cache->locateKey(bo, split_key);
     RegionClient client(this, loc.region);
     kvrpcpb::SplitRegionRequest req;
-    req.set_split_key(split_key);
+    *req.mutable_split_keys()->Add() = split_key;
     kvrpcpb::SplitRegionResponse resp;
     client.sendReqToRegion<RPC_NAME(SplitRegion)>(bo, req, &resp);
     if (resp.has_region_error())
     {
         throw Exception(resp.region_error().message(), RegionUnavailable);
     }
-    auto lr = resp.left();
-    auto rr = resp.right();
+    const auto & splitted_regions = resp.regions();
     region_cache->dropRegion(loc.region);
-    region_cache->getRegionByID(bo, RegionVerID(lr.id(), lr.region_epoch().conf_ver(), lr.region_epoch().version()));
-    region_cache->getRegionByID(bo, RegionVerID(rr.id(), rr.region_epoch().conf_ver(), rr.region_epoch().version()));
+    for (const auto & r : splitted_regions)
+    {
+        region_cache->getRegionByID(bo, RegionVerID{r.id(), r.region_epoch().conf_ver(), r.region_epoch().version()});
+    }
 }
 
-void Cluster::startBackgourndTasks()
+void Cluster::startBackgroundTasks()
 {
     thread_pool->start();
     thread_pool->enqueue([this] {

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -13,19 +13,18 @@ void Cluster::splitRegion(const std::string & split_key)
     auto loc = region_cache->locateKey(bo, split_key);
     RegionClient client(this, loc.region);
     kvrpcpb::SplitRegionRequest req;
-    *req.mutable_split_keys()->Add() = split_key;
+    req.set_split_key(split_key);
     kvrpcpb::SplitRegionResponse resp;
     client.sendReqToRegion<RPC_NAME(SplitRegion)>(bo, req, &resp);
     if (resp.has_region_error())
     {
         throw Exception(resp.region_error().message(), RegionUnavailable);
     }
-    const auto & splitted_regions = resp.regions();
+    auto lr = resp.left();
+    auto rr = resp.right();
     region_cache->dropRegion(loc.region);
-    for (const auto & r : splitted_regions)
-    {
-        region_cache->getRegionByID(bo, RegionVerID{r.id(), r.region_epoch().conf_ver(), r.region_epoch().version()});
-    }
+    region_cache->getRegionByID(bo, RegionVerID(lr.id(), lr.region_epoch().conf_ver(), lr.region_epoch().version()));
+    region_cache->getRegionByID(bo, RegionVerID(rr.id(), rr.region_epoch().conf_ver(), rr.region_epoch().version()));
 }
 
 void Cluster::startBackgroundTasks()

--- a/src/test/bank_test/bank_test.h
+++ b/src/test/bank_test/bank_test.h
@@ -24,7 +24,12 @@ struct BankCase
     std::thread check_thread;
 
     BankCase(Cluster * cluster_, int account_cnt_, int con_)
-        : cluster(cluster_), batch_size(100), stop(false), account_cnt(account_cnt_), start(account_cnt_ / batch_size), concurrency(con_)
+        : cluster(cluster_)
+        , batch_size(100)
+        , stop(false)
+        , account_cnt(account_cnt_)
+        , start(account_cnt_ / batch_size)
+        , concurrency(con_)
     {}
 
     void close()
@@ -51,6 +56,7 @@ struct BankCase
     {
         std::cerr << "bank case start to init\n";
         std::vector<std::thread> threads;
+        threads.reserve(concurrency);
         for (int i = 0; i < concurrency; i++)
         {
             threads.push_back(std::thread([&]() {
@@ -127,6 +133,7 @@ struct BankCase
     {
         std::cerr << "bank case start to execute\n";
         std::vector<std::thread> threads;
+        threads.reserve(concurrency);
         for (int i = 0; i < concurrency; i++)
         {
             threads.push_back(std::thread([&]() {
@@ -163,7 +170,7 @@ struct BankCase
         bool exists;
         std::tie(rest, exists) = txn.get(bank_key(from));
         assert(exists);
-        if (rest == "")
+        if (rest.empty())
             return;
         int rest_money = std::stoi(rest);
         int money = generator() % rest_money;
@@ -172,7 +179,7 @@ struct BankCase
 
         std::tie(rest, exists) = txn.get(bank_key(to));
         assert(exists);
-        if (rest == "")
+        if (rest.empty())
             return;
 
         rest_money = std::stoi(rest);
@@ -203,7 +210,7 @@ struct BankCase
     {
         char buff[12] = "";
         assert(idx < 10000 && idx >= 0);
-        std::sprintf(buff, "%04d", idx);
+        std::snprintf(buff, sizeof(buff), "%04d", idx);
         return "bankkey_" + std::string(buff);
     }
     std::string bank_value(int money) { return std::to_string(money); }


### PR DESCRIPTION
* Make `KeyspaceID` defined in a standalone header file to reduce include header in tiflash
* Fix typo `startBackgourndTasks` -> `startBackgroundTasks`
* <del>Use new fields instead of deprecated field in `Cluster::splitRegion` </del> this require updating `mock-tikv`. Will be done in another PR