### PR TITLE
support choosing non-pending tiflash peer when buildBatchCopTask

### DIFF
--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -204,6 +204,9 @@ public:
 
     Store getStore(Backoffer & bo, uint64_t id);
 
+    // Return values:
+    // 1. all stores of peers of this region
+    // 2. stores of non pending peers of this region
     std::pair<std::vector<uint64_t>, std::vector<uint64_t>> getAllValidTiFlashStores(Backoffer & bo, const RegionVerID & region_id, const Store & current_store, const LabelFilter & label_filter);
 
     std::pair<std::unordered_map<RegionVerID, std::vector<std::string>>, RegionVerID>

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -85,7 +85,6 @@ struct Region
 {
     metapb::Region meta;
     metapb::Peer leader_peer;
-    // This is just an indicator, maybe empty.
     std::vector<metapb::Peer> pending_peers;
     std::atomic_uint work_tiflash_peer_idx;
 

--- a/include/pingcap/pd/Client.h
+++ b/include/pingcap/pd/Client.h
@@ -44,9 +44,9 @@ public:
     // only implement a weak get ts.
     uint64_t getTS() override;
 
-    std::pair<metapb::Region, metapb::Peer> getRegionByKey(const std::string & key) override;
+    pdpb::GetRegionResponse getRegionByKey(const std::string & key) override;
 
-    std::pair<metapb::Region, metapb::Peer> getRegionByID(uint64_t region_id) override;
+    pdpb::GetRegionResponse getRegionByID(uint64_t region_id) override;
 
     metapb::Store getStore(uint64_t store_id) override;
 

--- a/include/pingcap/pd/CodecClient.h
+++ b/include/pingcap/pd/CodecClient.h
@@ -5,6 +5,7 @@
 #include <pingcap/pd/Client.h>
 
 #include <sstream>
+#include "pdpb.pb.h"
 
 namespace pingcap
 {
@@ -16,16 +17,18 @@ struct CodecClient : public Client
         : Client(addrs, config)
     {}
 
-    std::pair<metapb::Region, metapb::Peer> getRegionByKey(const std::string & key) override
+    pdpb::GetRegionResponse getRegionByKey(const std::string & key) override
     {
-        auto [region, leader] = Client::getRegionByKey(encodeBytes(key));
-        return std::make_pair(processRegionResult(region), leader);
+        auto resp = Client::getRegionByKey(encodeBytes(key));
+        processRegionResult(*resp.mutable_region());
+        return resp;
     }
 
-    std::pair<metapb::Region, metapb::Peer> getRegionByID(uint64_t region_id) override
+    pdpb::GetRegionResponse getRegionByID(uint64_t region_id) override
     {
-        auto [region, leader] = Client::getRegionByID(region_id);
-        return std::make_pair(processRegionResult(region), leader);
+        auto resp = Client::getRegionByID(region_id);
+        processRegionResult(*resp.mutable_region());
+        return resp;
     }
 
     static metapb::Region processRegionResult(metapb::Region & region)

--- a/include/pingcap/pd/CodecClient.h
+++ b/include/pingcap/pd/CodecClient.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <kvproto/pdpb.pb.h>
 #include <pingcap/Config.h>
 #include <pingcap/Exception.h>
 #include <pingcap/pd/Client.h>
 
 #include <sstream>
-#include "pdpb.pb.h"
 
 namespace pingcap
 {

--- a/include/pingcap/pd/IClient.h
+++ b/include/pingcap/pd/IClient.h
@@ -32,11 +32,9 @@ public:
 
     virtual uint64_t getTS() = 0;
 
-    // return region meta and leader peer.
-    virtual std::pair<metapb::Region, metapb::Peer> getRegionByKey(const std::string & key) = 0;
+    virtual pdpb::GetRegionResponse getRegionByKey(const std::string & key) = 0;
 
-    // return region meta and leader peer.
-    virtual std::pair<metapb::Region, metapb::Peer> getRegionByID(uint64_t region_id) = 0;
+    virtual pdpb::GetRegionResponse getRegionByID(uint64_t region_id) = 0;
 
     virtual metapb::Store getStore(uint64_t store_id) = 0;
 

--- a/include/pingcap/pd/MockPDClient.h
+++ b/include/pingcap/pd/MockPDClient.h
@@ -23,9 +23,9 @@ public:
 
     uint64_t getTS() override { return Clock::now().time_since_epoch().count(); }
 
-    std::pair<metapb::Region, metapb::Peer> getRegionByKey(const std::string &) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    pdpb::GetRegionResponse getRegionByKey(const std::string &) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
 
-    std::pair<metapb::Region, metapb::Peer> getRegionByID(uint64_t) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    pdpb::GetRegionResponse getRegionByID(uint64_t) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
 
     metapb::Store getStore(uint64_t) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
     std::vector<metapb::Store> getAllStores(bool) override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }

--- a/include/pingcap/pd/MockPDClient.h
+++ b/include/pingcap/pd/MockPDClient.h
@@ -21,7 +21,7 @@ public:
 
     uint64_t getGCSafePoint() override { return 10000000; }
 
-    uint64_t getGCSafePointV2(KeyspaceID keyspace_id) override { return 10000000; }
+    uint64_t getGCSafePointV2(KeyspaceID) override { return 10000000; }
 
     uint64_t getTS() override { return Clock::now().time_since_epoch().count(); }
 

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -395,7 +395,17 @@ std::vector<BatchCopTask> buildBatchCopTasks(
                 // Then `splitRegion` will reloads these regions.
                 continue;
             }
-            auto all_stores = cluster->region_cache->getAllValidTiFlashStores(bo, cop_task.region_id, rpc_context->store, label_filter);
+            auto [all_stores, non_pending_stores] = cluster->region_cache->getAllValidTiFlashStores(bo, cop_task.region_id, rpc_context->store, label_filter);
+            if (non_pending_stores.empty())
+            {
+                cluster->region_cache->dropRegion(cop_task.region_id);
+            }
+            else
+            {
+                all_stores = non_pending_stores;
+                if (all_stores.size() != non_pending_stores.size())
+                    cluster->region_cache->dropRegion(cop_task.region_id);
+            }
             if (auto iter = store_task_map.find(rpc_context->addr); iter == store_task_map.end())
             {
                 BatchCopTask batch_cop_task;

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -402,6 +402,7 @@ std::vector<BatchCopTask> buildBatchCopTasks(
                 cluster->region_cache->dropRegion(cop_task.region_id);
 
             // Use non_pending_stores to dispatch this task, so no need to wait tiflash replica sync from tikv.
+            // If all stores are in pending state, we use `all_stores` as fallback.
             if (!non_pending_stores.empty())
                 all_stores = non_pending_stores;
 

--- a/src/pd/Client.cc
+++ b/src/pd/Client.cc
@@ -320,7 +320,7 @@ uint64_t Client::getGCSafePoint()
     return response.safe_point();
 }
 
-std::pair<metapb::Region, metapb::Peer> Client::getRegionByKey(const std::string & key)
+pdpb::GetRegionResponse Client::getRegionByKey(const std::string & key)
 {
     pdpb::GetRegionRequest request{};
     pdpb::GetRegionResponse response{};
@@ -341,12 +341,10 @@ std::pair<metapb::Region, metapb::Peer> Client::getRegionByKey(const std::string
         throw Exception(err_msg, GRPCErrorCode);
     }
 
-    if (!response.has_region())
-        return {};
-    return std::make_pair(response.region(), response.leader());
+    return response;
 }
 
-std::pair<metapb::Region, metapb::Peer> Client::getRegionByID(uint64_t region_id)
+pdpb::GetRegionResponse Client::getRegionByID(uint64_t region_id)
 {
     pdpb::GetRegionByIDRequest request{};
     pdpb::GetRegionResponse response{};
@@ -367,10 +365,7 @@ std::pair<metapb::Region, metapb::Peer> Client::getRegionByID(uint64_t region_id
         throw Exception(err_msg, GRPCErrorCode);
     }
 
-    if (!response.has_region())
-        return {};
-
-    return std::make_pair(response.region(), response.leader());
+    return response;
 }
 
 std::vector<metapb::Store> Client::getAllStores(bool exclude_tombstone)


### PR DESCRIPTION
issue: https://github.com/pingcap/tiflash/issues/7301

Before: Task can dispatch to store whose region is still pending.
After: Try not to dispatch task to pending store.

What's changed:
1. Change function declaration of `getRegionByKey()` and `getRegionByID()`, return whole response instead of only region info.
2. Record pending store of region in region cache.
3. Try dispatch task to non_pending_store of region when buildBatchCopTasks.