### PR TITLE
Refactor RpcCall

### DIFF
--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -144,13 +144,12 @@ public:
     }
 
     // send all tasks.
-    template <bool is_stream>
     void open()
     {
         unfinished_thread = concurrency;
         for (int i = 0; i < concurrency; i++)
         {
-            std::thread worker(&ResponseIter::thread<is_stream>, this);
+            std::thread worker(&ResponseIter::thread, this);
             worker_threads.push_back(std::move(worker));
         }
         log->debug("coprocessor has " + std::to_string(tasks.size()) + " tasks.");
@@ -198,7 +197,6 @@ public:
     }
 
 private:
-    template <bool is_stream>
     void thread()
     {
         log->information("thread start.");
@@ -222,13 +220,11 @@ private:
             const CopTask & task = tasks[task_index];
             task_index++;
             lk.unlock();
-            handleTask<is_stream>(task);
+            handleTask(task);
         }
     }
 
-    template <bool is_stream>
     std::vector<CopTask> handleTaskImpl(kv::Backoffer & bo, const CopTask & task);
-    template <bool is_stream>
     void handleTask(const CopTask & task);
 
     size_t task_index = 0;

--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -144,12 +144,13 @@ public:
     }
 
     // send all tasks.
+    template <bool is_stream>
     void open()
     {
         unfinished_thread = concurrency;
         for (int i = 0; i < concurrency; i++)
         {
-            std::thread worker(&ResponseIter::thread, this);
+            std::thread worker(&ResponseIter::thread<is_stream>, this);
             worker_threads.push_back(std::move(worker));
         }
         log->debug("coprocessor has " + std::to_string(tasks.size()) + " tasks.");
@@ -197,6 +198,7 @@ public:
     }
 
 private:
+    template <bool is_stream>
     void thread()
     {
         log->information("thread start.");
@@ -220,11 +222,13 @@ private:
             const CopTask & task = tasks[task_index];
             task_index++;
             lk.unlock();
-            handleTask(task);
+            handleTask<is_stream>(task);
         }
     }
 
+    template <bool is_stream>
     std::vector<CopTask> handleTaskImpl(kv::Backoffer & bo, const CopTask & task);
+    template <bool is_stream>
     void handleTask(const CopTask & task);
 
     size_t task_index = 0;

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -140,7 +140,7 @@ struct AsyncResolveData
     // In this function, resp->locks is the list of locks, and expected is the number of keys. AsyncResolveData.missing_lock will be
     // set to true if the lengths don't match. If the lengths do match, then the locks are added to asyncResolveData.locks
     // and will need to be resolved by the caller.
-    void addKeys(std::shared_ptr<::kvrpcpb::CheckSecondaryLocksResponse> resp, int expected, uint64_t start_ts)
+    void addKeys(::kvrpcpb::CheckSecondaryLocksResponse * resp, int expected, uint64_t start_ts)
     {
         std::lock_guard l(mu);
 

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -77,6 +77,7 @@ struct RegionClient
             {
                 log->warning("region " + region_id.toString() + " find error: " + resp->region_error().message());
                 onRegionError(bo, ctx, resp->region_error());
+                continue;
             }
             return;
         }

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -36,10 +36,10 @@ struct RegionClient
     {}
 
     // This method send a request to region, but is NOT Thread-Safe !!
-    template <typename T, typename U, typename V>
+    template <typename T, typename REQ, typename RESP>
     void sendReqToRegion(Backoffer & bo,
-                         U & req,
-                         V * resp,
+                         REQ & req,
+                         RESP * resp,
                          const LabelFilter & tiflash_label_filter = kv::labelFilterInvalid,
                          int timeout = dailTimeout,
                          StoreType store_type = StoreType::TiKV,

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -38,7 +38,7 @@ struct RegionClient
     // This method send a request to region, but is NOT Thread-Safe !!
     template <typename T>
     void sendReqToRegion(Backoffer & bo,
-                         std::shared_ptr<typename T::RequestType> req,
+                         typename T::RequestType & req,
                          typename T::ResponseType * resp,
                          const LabelFilter & tiflash_label_filter = kv::labelFilterInvalid,
                          int timeout = dailTimeout,
@@ -57,7 +57,6 @@ struct RegionClient
                 // If the region is not found in cache, it must be out
                 // of date and already be cleaned up. We can skip the
                 // RPC by returning RegionError directly.
-
                 throw Exception("Region epoch not match after retries: Region " + region_id.toString() + " not in region cache.", RegionEpochNotMatch);
             }
             const auto & store_addr = ctx->addr;

--- a/include/pingcap/kv/Rpc.h
+++ b/include/pingcap/kv/Rpc.h
@@ -64,7 +64,7 @@ template <typename T>
 class RpcCall
 {
 public:
-    RpcCall(RpcClientPtr & client_, const std::string & addr_)
+    RpcCall(const RpcClientPtr & client_, const std::string & addr_)
         : client(client_)
         , addr(addr_)
         , log(&Logger::get("pingcap.tikv"))
@@ -117,7 +117,7 @@ public:
     }
 
 private:
-    RpcClientPtr & client;
+    const RpcClientPtr & client;
     const std::string & addr;
     Logger * log;
 };

--- a/include/pingcap/kv/Rpc.h
+++ b/include/pingcap/kv/Rpc.h
@@ -70,8 +70,8 @@ public:
         , log(&Logger::get("pingcap.tikv"))
     {}
 
-    template <typename U>
-    void setRequestCtx(U & req, RPCContextPtr rpc_ctx, kvrpcpb::APIVersion api_version)
+    template <typename REQ>
+    void setRequestCtx(REQ & req, RPCContextPtr rpc_ctx, kvrpcpb::APIVersion api_version)
     {
         // TODO: attach the API version with a better manner.
         // We check if the region range is in the keyspace, if it does, we use the API v2.
@@ -99,7 +99,7 @@ public:
     void setClientContext(::grpc::ClientContext & context, int timeout, const GRPCMetaData & meta_data = {})
     {
         context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(timeout));
-        for (auto & it : meta_data)
+        for (const auto & it : meta_data)
             context.AddMetadata(it.first, it.second);
     }
 

--- a/include/pingcap/kv/Rpc.h
+++ b/include/pingcap/kv/Rpc.h
@@ -71,7 +71,7 @@ public:
     {}
 
     template <typename U>
-    void setCtx(U & req, RPCContextPtr rpc_ctx, kvrpcpb::APIVersion api_version)
+    void setRequestCtx(U & req, RPCContextPtr rpc_ctx, kvrpcpb::APIVersion api_version)
     {
         // TODO: attach the API version with a better manner.
         // We check if the region range is in the keyspace, if it does, we use the API v2.
@@ -94,6 +94,13 @@ public:
         context->set_region_id(rpc_ctx->region.id);
         context->set_allocated_region_epoch(new metapb::RegionEpoch(rpc_ctx->meta.region_epoch()));
         context->set_allocated_peer(new metapb::Peer(rpc_ctx->peer));
+    }
+
+    void setClientContext(::grpc::ClientContext & context, int timeout, const GRPCMetaData & meta_data = {})
+    {
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(timeout));
+        for (auto & it : meta_data)
+            context.AddMetadata(it.first, it.second);
     }
 
     template <typename... Args>

--- a/include/pingcap/kv/Rpc.h
+++ b/include/pingcap/kv/Rpc.h
@@ -31,66 +31,6 @@ struct ConnArray
 using ConnArrayPtr = std::shared_ptr<ConnArray>;
 using GRPCMetaData = std::multimap<std::string, std::string>;
 
-// RpcCall holds the request and response, and delegates RPC calls.
-template <class T>
-class RpcCall
-{
-    using RequestType = typename T::RequestType;
-    using ResponseType = typename T::ResponseType;
-
-    RequestType & req;
-    Logger * log;
-
-public:
-    explicit RpcCall(RequestType & req_)
-        : req(req_)
-        , log(&Logger::get("pingcap.tikv"))
-    {}
-
-    void setCtx(RPCContextPtr rpc_ctx, kvrpcpb::APIVersion api_version)
-    {
-        // TODO: attach the API version with a better manner.
-        // We check if the region range is in the keyspace, if it does, we use the API v2.
-        kvrpcpb::APIVersion req_api_ver = kvrpcpb::APIVersion::V1;
-        if (api_version == kvrpcpb::APIVersion::V2)
-        {
-            auto start_key = rpc_ctx->meta.start_key();
-            auto end_key = rpc_ctx->meta.end_key();
-            std::string min_raw_v2_key = {'r', 0, 0, 0};
-            std::string max_raw_v2_key = {'s', 0, 0, 0};
-            std::string min_txn_v2_key = {'x', 0, 0, 0};
-            std::string max_txn_v2_key = {'y', 0, 0, 0};
-            if ((start_key >= min_raw_v2_key && end_key < min_raw_v2_key) || (start_key >= min_txn_v2_key && end_key < max_txn_v2_key))
-            {
-                req_api_ver = kvrpcpb::APIVersion::V2;
-            }
-        }
-        ::kvrpcpb::Context * context = req.mutable_context();
-        context->set_api_version(req_api_ver);
-        context->set_region_id(rpc_ctx->region.id);
-        context->set_allocated_region_epoch(new metapb::RegionEpoch(rpc_ctx->meta.region_epoch()));
-        context->set_allocated_peer(new metapb::Peer(rpc_ctx->peer));
-    }
-
-    void call(grpc::ClientContext * context, std::shared_ptr<KvConnClient> client, typename T::ResponseType * resp)
-    {
-        auto status = T::doRPCCall(context, client, req, resp);
-        if (!status.ok())
-        {
-            std::string err_msg = std::string(T::err_msg()) + std::to_string(status.error_code()) + ": " + status.error_message();
-            log->error(err_msg);
-            throw Exception(err_msg, GRPCErrorCode);
-        }
-    }
-
-    auto callStream(grpc::ClientContext * context, std::shared_ptr<KvConnClient> client) { return T::doRPCCall(context, client, *req); }
-
-    auto callStreamAsync(grpc::ClientContext * context, std::shared_ptr<KvConnClient> client, grpc::CompletionQueue & cq, void * call) { return T::doAsyncRPCCall(context, client, *req, cq, call); }
-};
-
-template <typename T>
-using RpcCallPtr = std::unique_ptr<RpcCall<T>>;
-
 struct RpcClient
 {
     ClusterConfig config;
@@ -115,33 +55,65 @@ struct RpcClient
     ConnArrayPtr getConnArray(const std::string & addr);
 
     ConnArrayPtr createConnArray(const std::string & addr);
-
-    template <class T>
-    void sendRequest(const std::string & addr, grpc::ClientContext * context, RpcCall<T> & rpc, typename T::ResponseType * resp)
-    {
-        ConnArrayPtr conn_array = getConnArray(addr);
-        auto conn_client = conn_array->get();
-        rpc.call(context, conn_client, resp);
-    }
-
-    template <class T>
-    auto sendStreamRequest(const std::string & addr, grpc::ClientContext * context, RpcCall<T> & rpc)
-    {
-        ConnArrayPtr conn_array = getConnArray(addr);
-        auto conn_client = conn_array->get();
-        return rpc.callStream(context, conn_client);
-    }
-
-    template <class T>
-    auto sendStreamRequestAsync(const std::string & addr, grpc::ClientContext * context, RpcCall<T> & rpc, grpc::CompletionQueue & cq, void * call)
-    {
-        ConnArrayPtr conn_array = getConnArray(addr);
-        auto conn_client = conn_array->get();
-        return rpc.callStreamAsync(context, conn_client, cq, call);
-    }
 };
 
 using RpcClientPtr = std::unique_ptr<RpcClient>;
+
+// RpcCall holds the request and response, and delegates RPC calls.
+template <typename T>
+class RpcCall
+{
+public:
+    RpcCall(RpcClientPtr & client_, const std::string & addr_)
+        : client(client_)
+        , addr(addr_)
+        , log(&Logger::get("pingcap.tikv"))
+    {}
+
+    template <typename U>
+    void setCtx(U & req, RPCContextPtr rpc_ctx, kvrpcpb::APIVersion api_version)
+    {
+        // TODO: attach the API version with a better manner.
+        // We check if the region range is in the keyspace, if it does, we use the API v2.
+        kvrpcpb::APIVersion req_api_ver = kvrpcpb::APIVersion::V1;
+        if (api_version == kvrpcpb::APIVersion::V2)
+        {
+            auto start_key = rpc_ctx->meta.start_key();
+            auto end_key = rpc_ctx->meta.end_key();
+            std::string min_raw_v2_key = {'r', 0, 0, 0};
+            std::string max_raw_v2_key = {'s', 0, 0, 0};
+            std::string min_txn_v2_key = {'x', 0, 0, 0};
+            std::string max_txn_v2_key = {'y', 0, 0, 0};
+            if ((start_key >= min_raw_v2_key && end_key < min_raw_v2_key) || (start_key >= min_txn_v2_key && end_key < max_txn_v2_key))
+            {
+                req_api_ver = kvrpcpb::APIVersion::V2;
+            }
+        }
+        ::kvrpcpb::Context * context = req.mutable_context();
+        context->set_api_version(req_api_ver);
+        context->set_region_id(rpc_ctx->region.id);
+        context->set_allocated_region_epoch(new metapb::RegionEpoch(rpc_ctx->meta.region_epoch()));
+        context->set_allocated_peer(new metapb::Peer(rpc_ctx->peer));
+    }
+
+    template <typename... Args>
+    auto call(Args &&... args)
+    {
+        ConnArrayPtr conn_array = client->getConnArray(addr);
+        auto conn_client = conn_array->get();
+        return T::call(conn_client, std::forward<Args>(args)...);
+    }
+
+    std::string errMsg(const ::grpc::Status & status)
+    {
+        return std::string(T::errMsg()) + std::to_string(status.error_code()) + ": " + status.error_message();
+    }
+
+private:
+    RpcClientPtr & client;
+    const std::string & addr;
+    Logger * log;
+};
 
 } // namespace kv
 } // namespace pingcap

--- a/include/pingcap/kv/internal/type_traits.h
+++ b/include/pingcap/kv/internal/type_traits.h
@@ -14,13 +14,14 @@ struct RpcTypeTraits
 {
 };
 
+#define RPC_NAME(METHOD) RpcType##METHOD
+
 // Note that this macro is only applicable for grpc unary call
 #define PINGCAP_DEFINE_TRAITS(NAMESPACE, NAME, METHOD)      \
-    template <>                                             \
-    struct RpcTypeTraits<::NAMESPACE::NAME##Request>        \
+    struct RPC_NAME(METHOD)        \
     {                                                       \
         using RequestType = ::NAMESPACE::NAME##Request;     \
-        using ResultType = ::NAMESPACE::NAME##Response;     \
+        using ResponseType = ::NAMESPACE::NAME##Response;     \
         static const char * err_msg()                       \
         {                                                   \
             return #NAME " Failed";                         \
@@ -29,7 +30,7 @@ struct RpcTypeTraits
             grpc::ClientContext * context,                  \
             std::shared_ptr<KvConnClient> client,           \
             const RequestType & req,                        \
-            ResultType * res)                               \
+            ResponseType * res)                               \
         {                                                   \
             return client->stub->METHOD(context, req, res); \
         }                                                   \

--- a/include/pingcap/kv/internal/type_traits.h
+++ b/include/pingcap/kv/internal/type_traits.h
@@ -9,78 +9,156 @@ namespace pingcap
 {
 namespace kv
 {
-template <class T>
-struct RpcTypeTraits
-{
-};
 
-#define RPC_NAME(METHOD) RpcType##METHOD
+#define RPC_NAME(METHOD) RpcTrait##METHOD
 
-// Note that this macro is only applicable for grpc unary call
-#define PINGCAP_DEFINE_TRAITS(NAMESPACE, NAME, METHOD)      \
-    struct RPC_NAME(METHOD)        \
-    {                                                       \
-        using RequestType = ::NAMESPACE::NAME##Request;     \
-        using ResponseType = ::NAMESPACE::NAME##Response;     \
-        static const char * err_msg()                       \
-        {                                                   \
-            return #NAME " Failed";                         \
-        }                                                   \
-        static ::grpc::Status doRPCCall(                    \
-            grpc::ClientContext * context,                  \
-            std::shared_ptr<KvConnClient> client,           \
-            const RequestType & req,                        \
-            ResponseType * res)                               \
-        {                                                   \
-            return client->stub->METHOD(context, req, res); \
-        }                                                   \
+#define GRPC_TRAIT(METHOD)                                                   \
+    struct RPC_NAME(METHOD)                                                  \
+    {                                                                        \
+        static const char * errMsg()                                         \
+        {                                                                    \
+            return #METHOD " Failed";                                        \
+        }                                                                    \
+        template <typename... Args>                                          \
+        static auto call(                                                    \
+            std::shared_ptr<KvConnClient> client,                            \
+            Args &&... args)                                                 \
+        {                                                                    \
+            return client->stub->METHOD(std::forward<Args>(args)...);        \
+        }                                                                    \
+    };                                                                       \
+    struct RPC_NAME(Async##METHOD)                                           \
+    {                                                                        \
+        static const char * err_msg()                                        \
+        {                                                                    \
+            return "Async" #METHOD " Failed";                                \
+        }                                                                    \
+        template <typename... Args>                                          \
+        static auto call(                                                    \
+            std::shared_ptr<KvConnClient> client,                            \
+            Args &&... args)                                                 \
+        {                                                                    \
+            return client->stub->Async##METHOD(std::forward<Args>(args)...); \
+        }                                                                    \
     };
 
-PINGCAP_DEFINE_TRAITS(kvrpcpb, SplitRegion, SplitRegion)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, Commit, KvCommit)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, Prewrite, KvPrewrite)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, Scan, KvScan)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, Get, KvGet)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, MvccGetByKey, MvccGetByKey)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, ReadIndex, ReadIndex)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, CheckTxnStatus, KvCheckTxnStatus)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, ResolveLock, KvResolveLock)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, PessimisticRollback, KVPessimisticRollback)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, TxnHeartBeat, KvTxnHeartBeat)
-PINGCAP_DEFINE_TRAITS(kvrpcpb, CheckSecondaryLocks, KvCheckSecondaryLocks)
-PINGCAP_DEFINE_TRAITS(disaggregated, EstablishDisaggTask, EstablishDisaggTask)
-PINGCAP_DEFINE_TRAITS(disaggregated, CancelDisaggTask, CancelDisaggTask)
-PINGCAP_DEFINE_TRAITS(coprocessor, , Coprocessor)
-PINGCAP_DEFINE_TRAITS(mpp, DispatchTask, DispatchMPPTask)
-PINGCAP_DEFINE_TRAITS(mpp, CancelTask, CancelMPPTask)
-PINGCAP_DEFINE_TRAITS(mpp, IsAlive, IsAlive)
-PINGCAP_DEFINE_TRAITS(mpp, ReportTaskStatus, ReportMPPTaskStatus)
+#define M(method) GRPC_TRAIT(method)
+// Commands using a transactional interface.
+M(KvGet)
+M(KvScan)
+M(KvPrewrite)
+M(KvPessimisticLock)
+M(KVPessimisticRollback)
+M(KvTxnHeartBeat)
+M(KvCheckTxnStatus)
+M(KvCheckSecondaryLocks)
+M(KvCommit)
+M(KvCleanup)
+M(KvBatchGet)
+M(KvBatchRollback)
+M(KvScanLock)
+M(KvResolveLock)
+M(KvGC)
+M(KvDeleteRange)
+M(KvPrepareFlashbackToVersion)
+M(KvFlashbackToVersion)
 
-// streaming trait for BatchRequest
-template <>
-struct RpcTypeTraits<::coprocessor::BatchRequest>
-{
-    using RequestType = ::coprocessor::BatchRequest;
-    using ResultType = ::coprocessor::BatchResponse;
+// Raw commands; no transaction support.
+M(RawGet)
+M(RawBatchGet)
+M(RawPut)
+M(RawBatchPut)
+M(RawDelete)
+M(RawBatchDelete)
+M(RawScan)
+M(RawDeleteRange)
+M(RawBatchScan)
+// Get TTL of the key. Returns 0 if TTL is not set for the key.
+M(RawGetKeyTTL)
+// Compare if the value in database equals to `RawCASRequest.previous_value` before putting the new value. If not, this request will have no effect and the value in the database will be returned.
+M(RawCompareAndSwap)
+M(RawChecksum)
 
-    static std::unique_ptr<::grpc::ClientReader<ResultType>> doRPCCall(
-        grpc::ClientContext * context,
-        std::shared_ptr<KvConnClient> client,
-        const RequestType & req)
-    {
-        return client->stub->BatchCoprocessor(context, req);
-    }
+// Store commands (sent to a each TiKV node in a cluster, rather than a certain region).
+M(UnsafeDestroyRange)
+M(RegisterLockObserver)
+M(CheckLockObserver)
+M(RemoveLockObserver)
+M(PhysicalScanLock)
 
-    static std::unique_ptr<::grpc::ClientAsyncReader<ResultType>> doAsyncRPCCall(
-        grpc::ClientContext * context,
-        std::shared_ptr<KvConnClient> client,
-        const RequestType & req,
-        grpc::CompletionQueue & cq,
-        void * call)
-    {
-        return client->stub->AsyncBatchCoprocessor(context, req, &cq, call);
-    }
-};
+// Commands for executing SQL in the TiKV coprocessor (i.e., 'pushed down' to TiKV rather than
+// executed in TiDB).
+M(Coprocessor)
+M(CoprocessorStream)
+M(BatchCoprocessor)
+
+// Command for executing custom user requests in TiKV coprocessor_v2.
+M(RawCoprocessor)
+
+// Raft commands (sent between TiKV nodes).
+M(Raft)
+M(BatchRaft)
+M(Snapshot)
+M(TabletSnapshot)
+
+// Sent from PD or TiDB to a TiKV node.
+M(SplitRegion)
+// Sent from TiFlash or TiKV to a TiKV node.
+M(ReadIndex)
+
+// Commands for debugging transactions.
+M(MvccGetByKey)
+M(MvccGetByStartTs)
+
+// Batched commands.
+M(BatchCommands)
+
+// These are for mpp execution.
+M(DispatchMPPTask)
+M(CancelMPPTask)
+M(EstablishMPPConnection)
+M(IsAlive)
+M(ReportMPPTaskStatus)
+
+/// CheckLeader sends all information (includes region term and epoch) to other stores.
+/// Once a store receives a request, it checks term and epoch for each region, and sends the regions whose
+/// term and epoch match with local information in the store.
+/// After the client collected all responses from all stores, it checks if got a quorum of responses from
+/// other stores for every region, and decides to advance resolved ts from these regions.
+M(CheckLeader)
+
+/// Get the minimal `safe_ts` from regions at the store
+M(GetStoreSafeTS)
+
+/// Get the information about lock waiting from TiKV.
+M(GetLockWaitInfo)
+
+/// Compact a specified key range. This request is not restricted to raft leaders and will not be replicated.
+/// It only compacts data on this node.
+/// TODO: Currently this RPC is designed to be only compatible with TiFlash.
+/// Shall be move out in https://github.com/pingcap/kvproto/issues/912
+M(Compact)
+/// Get the information about history lock waiting from TiKV.
+M(GetLockWaitHistory)
+
+/// Get system table from TiFlash
+M(GetTiFlashSystemTable)
+
+// These are for TiFlash disaggregated architecture
+/// Try to lock a S3 object, atomically
+M(tryAddLock)
+/// Try to delete a S3 object, atomically
+M(tryMarkDelete)
+/// Build the disaggregated task on TiFlash write node
+M(EstablishDisaggTask)
+/// Cancel the disaggregated task on TiFlash write node
+M(CancelDisaggTask)
+/// Exchange page data between TiFlash write node and compute node
+M(FetchDisaggPages)
+/// Compute node get configuration from Write node
+M(GetDisaggConfig)
+
+#undef M
 
 } // namespace kv
 } // namespace pingcap

--- a/include/pingcap/pd/Client.h
+++ b/include/pingcap/pd/Client.h
@@ -77,6 +77,7 @@ public:
     resource_manager::DeleteResourceGroupResponse deleteResourceGroup(const resource_manager::DeleteResourceGroupRequest &) override;
 
     std::shared_ptr<grpc::ClientReaderWriter<resource_manager::TokenBucketsRequest, resource_manager::TokenBucketsResponse>> acquireTokenBuckets() override;
+
 private:
     void initClusterID();
 

--- a/include/pingcap/pd/MockPDClient.h
+++ b/include/pingcap/pd/MockPDClient.h
@@ -43,22 +43,34 @@ public:
     std::string getLeaderUrl() override { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
 
     ::resource_manager::ListResourceGroupsResponse listResourceGroups(const ::resource_manager::ListResourceGroupsRequest &) override
-    { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    {
+        throw Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
 
     ::resource_manager::GetResourceGroupResponse getResourceGroup(const ::resource_manager::GetResourceGroupRequest &) override
-    { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    {
+        throw Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
 
     ::resource_manager::PutResourceGroupResponse addResourceGroup(const ::resource_manager::PutResourceGroupRequest &) override
-    { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    {
+        throw Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
 
     ::resource_manager::PutResourceGroupResponse modifyResourceGroup(const ::resource_manager::PutResourceGroupRequest &) override
-    { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    {
+        throw Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
 
     ::resource_manager::DeleteResourceGroupResponse deleteResourceGroup(const ::resource_manager::DeleteResourceGroupRequest &) override
-    { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    {
+        throw Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
 
     std::shared_ptr<grpc::ClientReaderWriter<resource_manager::TokenBucketsRequest, resource_manager::TokenBucketsResponse>> acquireTokenBuckets() override
-    { throw Exception("not implemented", pingcap::ErrorCodes::UnknownError); }
+    {
+        throw Exception("not implemented", pingcap::ErrorCodes::UnknownError);
+    }
 };
 
 } // namespace pd

--- a/src/common/MPPProber.cc
+++ b/src/common/MPPProber.cc
@@ -87,8 +87,7 @@ void MPPProber::scan()
         else
         {
             // Store is dead, we want to check if this store has not used for MAX_OBSOLET_TIME.
-            if (ele.second->last_lookup_timepoint != INVALID_TIME_POINT &&
-                    getElapsed(ele.second->last_lookup_timepoint) > std::chrono::duration_cast<std::chrono::seconds>(MAX_OBSOLET_TIME_LIMIT))
+            if (ele.second->last_lookup_timepoint != INVALID_TIME_POINT && getElapsed(ele.second->last_lookup_timepoint) > std::chrono::duration_cast<std::chrono::seconds>(MAX_OBSOLET_TIME_LIMIT))
                 recovery_stores.push_back(ele.first);
         }
         ele.second->state_lock.unlock();
@@ -124,18 +123,15 @@ void ProbeState::detectAndUpdateState(const std::chrono::seconds & detect_period
 
 bool detectStore(kv::RpcClientPtr & rpc_client, const std::string & store_addr, int rpc_timeout, Logger * log)
 {
-    ::mpp::IsAliveRequest request;
-    kv::RpcCall<kv::RPC_NAME(IsAlive)> rpc(request);
+    kv::RpcCall<kv::RPC_NAME(IsAlive)> rpc(rpc_client, store_addr);
     grpc::ClientContext context;
     context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(rpc_timeout));
+    ::mpp::IsAliveRequest req;
     ::mpp::IsAliveResponse resp;
-    try
+    auto status = rpc.call(&context, req, &resp);
+    if (!status.ok())
     {
-        rpc_client->sendRequest(store_addr, &context, rpc, &resp);
-    }
-    catch (const Exception & e)
-    {
-        log->warning("detect failed: " + store_addr + " error: ", e.message());
+        log->warning("detect failed: " + store_addr + " error: ", rpc.errMsg(status));
         return false;
     }
 

--- a/src/common/MPPProber.cc
+++ b/src/common/MPPProber.cc
@@ -124,7 +124,8 @@ void ProbeState::detectAndUpdateState(const std::chrono::seconds & detect_period
 
 bool detectStore(kv::RpcClientPtr & rpc_client, const std::string & store_addr, int rpc_timeout, Logger * log)
 {
-    kv::RpcCall<kv::RPC_NAME(IsAlive)> rpc(std::make_shared<::mpp::IsAliveRequest>());
+    ::mpp::IsAliveRequest request;
+    kv::RpcCall<kv::RPC_NAME(IsAlive)> rpc(request);
     grpc::ClientContext context;
     context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(rpc_timeout));
     ::mpp::IsAliveResponse resp;

--- a/src/common/MPPProber.cc
+++ b/src/common/MPPProber.cc
@@ -125,7 +125,7 @@ bool detectStore(kv::RpcClientPtr & rpc_client, const std::string & store_addr, 
 {
     kv::RpcCall<kv::RPC_NAME(IsAlive)> rpc(rpc_client, store_addr);
     grpc::ClientContext context;
-    context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(rpc_timeout));
+    rpc.setClientContext(context, rpc_timeout);
     ::mpp::IsAliveRequest req;
     ::mpp::IsAliveResponse resp;
     auto status = rpc.call(&context, req, &resp);

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -529,7 +529,7 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
     std::shared_ptr<::coprocessor::Response> resp;
     try
     {
-        resp = client.sendReqToRegion(bo, req, tiflash_label_filter, kv::copTimeout, task.store_type, task.meta_data);
+        client.sendReqToRegion<kv::RPC_NAME(Coprocessor)>(bo, req, resp.get(), tiflash_label_filter, kv::copTimeout, task.store_type, task.meta_data);
     }
     catch (Exception & e)
     {

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -501,25 +501,25 @@ std::vector<BatchCopTask> buildBatchCopTasks(
 
 std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopTask & task)
 {
-    auto req = std::make_shared<::coprocessor::Request>();
-    auto * ctx = req->mutable_context();
+    ::coprocessor::Request req;
+    auto * ctx = req.mutable_context();
     if (task.keyspace_id != pd::NullspaceID)
     {
         ctx->set_api_version(kvrpcpb::APIVersion::V2);
         ctx->set_keyspace_id(task.keyspace_id);
     }
-    req->set_tp(task.req->tp);
-    req->set_start_ts(task.req->start_ts);
-    req->set_schema_ver(task.req->schema_version);
-    req->set_data(task.req->data);
-    req->set_is_cache_enabled(false);
+    req.set_tp(task.req->tp);
+    req.set_start_ts(task.req->start_ts);
+    req.set_schema_ver(task.req->schema_version);
+    req.set_data(task.req->data);
+    req.set_is_cache_enabled(false);
     for (auto ts : min_commit_ts_pushed.getTimestamps())
     {
-        req->mutable_context()->add_resolved_locks(ts);
+        req.mutable_context()->add_resolved_locks(ts);
     }
     for (const auto & range : task.ranges)
     {
-        auto * pb_range = req->add_ranges();
+        auto * pb_range = req.add_ranges();
         range.setKeyRange(pb_range);
     }
 

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -526,7 +526,7 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
     if (task.before_send)
         task.before_send();
     kv::RegionClient client(cluster, task.region_id);
-    std::shared_ptr<::coprocessor::Response> resp;
+    auto resp = std::make_shared<::coprocessor::Response>();
     try
     {
         client.sendReqToRegion<kv::RPC_NAME(Coprocessor)>(bo, req, resp.get(), tiflash_label_filter, kv::copTimeout, task.store_type, task.meta_data);

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -499,7 +499,6 @@ std::vector<BatchCopTask> buildBatchCopTasks(
     }
 }
 
-template <bool is_stream>
 std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopTask & task)
 {
     ::coprocessor::Request req;
@@ -570,7 +569,6 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
     return {};
 }
 
-template <bool is_stream>
 void ResponseIter::handleTask(const CopTask & task)
 {
     std::unordered_map<uint64_t, kv::Backoffer> bo_maps;
@@ -584,7 +582,7 @@ void ResponseIter::handleTask(const CopTask & task)
         {
             auto & current_task = remain_tasks[idx];
             auto & bo = bo_maps.try_emplace(current_task.region_id.id, kv::copNextMaxBackoff).first->second;
-            auto new_tasks = handleTaskImpl<is_stream>(bo, current_task);
+            auto new_tasks = handleTaskImpl(bo, current_task);
             if (!new_tasks.empty())
             {
                 remain_tasks.insert(remain_tasks.end(), new_tasks.begin(), new_tasks.end());

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -499,6 +499,7 @@ std::vector<BatchCopTask> buildBatchCopTasks(
     }
 }
 
+template <bool is_stream>
 std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopTask & task)
 {
     ::coprocessor::Request req;
@@ -569,6 +570,7 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
     return {};
 }
 
+template <bool is_stream>
 void ResponseIter::handleTask(const CopTask & task)
 {
     std::unordered_map<uint64_t, kv::Backoffer> bo_maps;
@@ -582,7 +584,7 @@ void ResponseIter::handleTask(const CopTask & task)
         {
             auto & current_task = remain_tasks[idx];
             auto & bo = bo_maps.try_emplace(current_task.region_id.id, kv::copNextMaxBackoff).first->second;
-            auto new_tasks = handleTaskImpl(bo, current_task);
+            auto new_tasks = handleTaskImpl<is_stream>(bo, current_task);
             if (!new_tasks.empty())
             {
                 remain_tasks.insert(remain_tasks.end(), new_tasks.begin(), new_tasks.end());

--- a/src/kv/2pc.cc
+++ b/src/kv/2pc.cc
@@ -168,7 +168,7 @@ void TwoPhaseCommitter::prewriteSingleBatch(Backoffer & bo, const BatchKeys & ba
             req.set_min_commit_ts(start_ts + 1);
         }
 
-        fiu_do_on("invalid_max_commit_ts", { req->set_max_commit_ts(min_commit_ts - 1); });
+        fiu_do_on("invalid_max_commit_ts", { req.set_max_commit_ts(min_commit_ts - 1); });
 
         kvrpcpb::PrewriteResponse response;
         RegionClient region_client(cluster, batch.region);

--- a/src/kv/2pc.cc
+++ b/src/kv/2pc.cc
@@ -170,11 +170,11 @@ void TwoPhaseCommitter::prewriteSingleBatch(Backoffer & bo, const BatchKeys & ba
 
         fiu_do_on("invalid_max_commit_ts", { req->set_max_commit_ts(min_commit_ts - 1); });
 
-        std::shared_ptr<kvrpcpb::PrewriteResponse> response;
+        kvrpcpb::PrewriteResponse response;
         RegionClient region_client(cluster, batch.region);
         try
         {
-            response = region_client.sendReqToRegion(bo, req);
+            region_client.sendReqToRegion<RPC_NAME(KvPrewrite)>(bo, req, &response);
         }
         catch (Exception & e)
         {
@@ -184,13 +184,13 @@ void TwoPhaseCommitter::prewriteSingleBatch(Backoffer & bo, const BatchKeys & ba
             return;
         }
 
-        if (response->errors_size() != 0)
+        if (response.errors_size() != 0)
         {
             std::vector<LockPtr> locks;
-            int size = response->errors_size();
+            int size = response.errors_size();
             for (int i = 0; i < size; i++)
             {
-                const auto & err = response->errors(i);
+                const auto & err = response.errors(i);
                 if (err.has_already_exist())
                 {
                     throw Exception("key : " + Redact::keyToDebugString(err.already_exist().key()) + " has existed.", LogicalError);
@@ -222,7 +222,7 @@ void TwoPhaseCommitter::prewriteSingleBatch(Backoffer & bo, const BatchKeys & ba
 
             if (use_async_commit)
             {
-                if (response->min_commit_ts() == 0)
+                if (response.min_commit_ts() == 0)
                 {
                     log->warning("async commit cannot proceed since the returned minCommitTS is zero, fallback to normal path");
                     use_async_commit = false;
@@ -230,9 +230,9 @@ void TwoPhaseCommitter::prewriteSingleBatch(Backoffer & bo, const BatchKeys & ba
                 else
                 {
                     commit_ts_mu.lock();
-                    if (response->min_commit_ts() > min_commit_ts)
+                    if (response.min_commit_ts() > min_commit_ts)
                     {
-                        min_commit_ts = response->min_commit_ts();
+                        min_commit_ts = response.min_commit_ts();
                     }
                     commit_ts_mu.unlock();
                 }
@@ -253,11 +253,11 @@ void TwoPhaseCommitter::commitSingleBatch(Backoffer & bo, const BatchKeys & batc
     req->set_start_version(start_ts);
     req->set_commit_version(commit_ts);
 
-    std::shared_ptr<kvrpcpb::CommitResponse> response;
+    kvrpcpb::CommitResponse response;
     RegionClient region_client(cluster, batch.region);
     try
     {
-        response = region_client.sendReqToRegion(bo, req);
+        region_client.sendReqToRegion<RPC_NAME(KvCommit)>(bo, req, &response);
     }
     catch (Exception & e)
     {
@@ -266,9 +266,9 @@ void TwoPhaseCommitter::commitSingleBatch(Backoffer & bo, const BatchKeys & batc
         commitKeys(bo, batch.keys);
         return;
     }
-    if (response->has_error())
+    if (response.has_error())
     {
-        throw Exception("meet errors: " + response->error().ShortDebugString(), LockError);
+        throw Exception("meet errors: " + response.error().ShortDebugString(), LockError);
     }
 
     commited = true;
@@ -286,22 +286,22 @@ uint64_t sendTxnHeartBeat(Backoffer & bo, Cluster * cluster, std::string & prima
         req->set_advise_lock_ttl(ttl);
 
         RegionClient client(cluster, loc.region);
-        std::shared_ptr<kvrpcpb::TxnHeartBeatResponse> response;
+        kvrpcpb::TxnHeartBeatResponse response;
         try
         {
-            response = client.sendReqToRegion(bo, req);
+            client.sendReqToRegion<RPC_NAME(KvTxnHeartBeat)>(bo, req, &response);
         }
         catch (Exception & e)
         {
             bo.backoff(boRegionMiss, e);
             continue;
         }
-        if (response->has_error())
+        if (response.has_error())
         {
-            throw Exception("unexpected err :" + response->error().ShortDebugString(), ErrorCodes::UnknownError);
+            throw Exception("unexpected err :" + response.error().ShortDebugString(), ErrorCodes::UnknownError);
         }
 
-        return response->lock_ttl();
+        return response.lock_ttl();
     }
 }
 

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -14,13 +14,14 @@ void Cluster::splitRegion(const std::string & split_key)
     RegionClient client(this, loc.region);
     auto req = std::make_shared<kvrpcpb::SplitRegionRequest>();
     req->set_split_key(split_key);
-    auto resp = client.sendReqToRegion(bo, req);
-    if (resp->has_region_error())
+    kvrpcpb::SplitRegionResponse resp;
+    client.sendReqToRegion<RPC_NAME(SplitRegion)>(bo, req, &resp);
+    if (resp.has_region_error())
     {
-        throw Exception(resp->region_error().message(), RegionUnavailable);
+        throw Exception(resp.region_error().message(), RegionUnavailable);
     }
-    auto lr = resp->left();
-    auto rr = resp->right();
+    auto lr = resp.left();
+    auto rr = resp.right();
     region_cache->dropRegion(loc.region);
     region_cache->getRegionByID(bo, RegionVerID(lr.id(), lr.region_epoch().conf_ver(), lr.region_epoch().version()));
     region_cache->getRegionByID(bo, RegionVerID(rr.id(), rr.region_epoch().conf_ver(), rr.region_epoch().version()));

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -12,8 +12,8 @@ void Cluster::splitRegion(const std::string & split_key)
     Backoffer bo(splitRegionBackoff);
     auto loc = region_cache->locateKey(bo, split_key);
     RegionClient client(this, loc.region);
-    auto req = std::make_shared<kvrpcpb::SplitRegionRequest>();
-    req->set_split_key(split_key);
+    kvrpcpb::SplitRegionRequest req;
+    req.set_split_key(split_key);
     kvrpcpb::SplitRegionResponse resp;
     client.sendReqToRegion<RPC_NAME(SplitRegion)>(bo, req, &resp);
     if (resp.has_region_error())

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -156,13 +156,13 @@ TxnStatus LockResolver::getTxnStatus(Backoffer & bo, uint64_t txn_id, const std:
     }
     TxnStatus status;
 
-    auto req = std::make_shared<::kvrpcpb::CheckTxnStatusRequest>();
-    req->set_primary_key(primary);
-    req->set_lock_ts(txn_id);
-    req->set_caller_start_ts(caller_start_ts);
-    req->set_current_ts(current_ts);
-    req->set_rollback_if_not_exist(rollback_if_not_exists);
-    req->set_force_sync_commit(force_sync_commit);
+    ::kvrpcpb::CheckTxnStatusRequest req;
+    req.set_primary_key(primary);
+    req.set_lock_ts(txn_id);
+    req.set_caller_start_ts(caller_start_ts);
+    req.set_current_ts(current_ts);
+    req.set_rollback_if_not_exist(rollback_if_not_exists);
+    req.set_force_sync_commit(force_sync_commit);
     for (;;)
     {
         auto loc = cluster->region_cache->locateKey(bo, primary);
@@ -225,13 +225,13 @@ void LockResolver::resolveLock(Backoffer & bo, LockPtr lock, TxnStatus & status,
         {
             return;
         }
-        auto req = std::make_shared<::kvrpcpb::ResolveLockRequest>();
-        req->set_start_version(lock->txn_id);
+        ::kvrpcpb::ResolveLockRequest req;
+        req.set_start_version(lock->txn_id);
         if (status.isCommitted())
-            req->set_commit_version(status.commit_ts);
+            req.set_commit_version(status.commit_ts);
         if (lock->txn_size < bigTxnThreshold)
         {
-            req->add_keys(lock->key);
+            req.add_keys(lock->key);
             if (!status.isCommitted())
             {
                 log->information("resolveLock rollback lock " + lock->toDebugString());
@@ -274,10 +274,10 @@ void LockResolver::resolvePessimisticLock(Backoffer & bo, LockPtr lock, std::uno
         {
             lock_for_update_ts = std::numeric_limits<uint64_t>::max();
         }
-        auto req = std::make_shared<::kvrpcpb::PessimisticRollbackRequest>();
-        req->set_start_version(lock->txn_id);
-        req->set_for_update_ts(lock_for_update_ts);
-        req->add_keys(lock->key);
+        ::kvrpcpb::PessimisticRollbackRequest req;
+        req.set_start_version(lock->txn_id);
+        req.set_for_update_ts(lock_for_update_ts);
+        req.add_keys(lock->key);
         RegionClient client(cluster, loc.region);
         ::kvrpcpb::PessimisticRollbackResponse response;
         try
@@ -348,17 +348,17 @@ void LockResolver::resolveRegionLocks(
     std::vector<std::string> & keys,
     TxnStatus & status)
 {
-    auto req = std::make_shared<::kvrpcpb::ResolveLockRequest>();
-    req->set_start_version(lock->txn_id);
+    ::kvrpcpb::ResolveLockRequest req;
+    req.set_start_version(lock->txn_id);
 
     if (status.isCommitted())
     {
-        req->set_commit_version(status.commit_ts);
+        req.set_commit_version(status.commit_ts);
     }
 
     for (auto & key : keys)
     {
-        auto * k = req->add_keys();
+        auto * k = req.add_keys();
         *k = key;
     }
 
@@ -442,13 +442,13 @@ void LockResolver::checkSecondaries(
     RegionVerID cur_region_id,
     AsyncResolveDataPtr shared_data)
 {
-    auto check_request = std::make_shared<::kvrpcpb::CheckSecondaryLocksRequest>();
+    ::kvrpcpb::CheckSecondaryLocksRequest check_request;
     for (auto & key : cur_keys)
     {
-        auto * k = check_request->add_keys();
+        auto * k = check_request.add_keys();
         *k = key;
     }
-    check_request->set_start_version(txn_id);
+    check_request.set_start_version(txn_id);
 
     RegionClient client(cluster, cur_region_id);
     ::kvrpcpb::CheckSecondaryLocksResponse response;

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -264,7 +264,7 @@ std::pair<std::vector<uint64_t>, std::vector<uint64_t>> RegionCache::getAllValid
                 break;
             }
         }
-        if (!is_pending) 
+        if (!is_pending)
             non_pending_stores.emplace_back(peer.store_id());
     }
     return std::make_pair(all_stores, non_pending_stores);

--- a/src/kv/Scanner.cc
+++ b/src/kv/Scanner.cc
@@ -63,14 +63,14 @@ void Scanner::getData(Backoffer & bo)
 
 
         auto region_client = RegionClient(snap.cluster, loc.region);
-        auto request = std::make_shared<kvrpcpb::ScanRequest>();
-        request->set_start_key(next_start_key);
-        request->set_end_key(req_end_key);
-        request->set_limit(batch);
-        request->set_version(snap.version);
-        request->set_key_only(false);
+        kvrpcpb::ScanRequest request;
+        request.set_start_key(next_start_key);
+        request.set_end_key(req_end_key);
+        request.set_limit(batch);
+        request.set_version(snap.version);
+        request.set_key_only(false);
 
-        auto * context = request->mutable_context();
+        auto * context = request.mutable_context();
         context->set_priority(::kvrpcpb::Normal);
         context->set_not_fill_cache(false);
 

--- a/src/kv/Snapshot.cc
+++ b/src/kv/Snapshot.cc
@@ -1,8 +1,8 @@
 #include <pingcap/Exception.h>
+#include <pingcap/Log.h>
 #include <pingcap/kv/Backoff.h>
 #include <pingcap/kv/Scanner.h>
 #include <pingcap/kv/Snapshot.h>
-#include <pingcap/Log.h>
 
 namespace pingcap
 {

--- a/src/kv/Snapshot.cc
+++ b/src/kv/Snapshot.cc
@@ -22,9 +22,9 @@ kvrpcpb::MvccInfo Snapshot::mvccGet(Backoffer & bo, const std::string & key)
 {
     for (;;)
     {
-        auto request = std::make_shared<kvrpcpb::MvccGetByKeyRequest>();
-        request->set_key(key);
-        ::kvrpcpb::Context * context = request->mutable_context();
+        kvrpcpb::MvccGetByKeyRequest request;
+        request.set_key(key);
+        ::kvrpcpb::Context * context = request.mutable_context();
         context->set_priority(::kvrpcpb::Normal);
         context->set_not_fill_cache(false);
         for (auto ts : min_commit_ts_pushed.getTimestamps())
@@ -65,10 +65,10 @@ std::string Snapshot::Get(Backoffer & bo, const std::string & key)
 {
     for (;;)
     {
-        auto request = std::make_shared<kvrpcpb::GetRequest>();
-        request->set_key(key);
-        request->set_version(version);
-        ::kvrpcpb::Context * context = request->mutable_context();
+        kvrpcpb::GetRequest request;
+        request.set_key(key);
+        request.set_version(version);
+        ::kvrpcpb::Context * context = request.mutable_context();
         context->set_priority(::kvrpcpb::Normal);
         context->set_not_fill_cache(false);
         for (auto ts : min_commit_ts_pushed.getTimestamps())

--- a/src/pd/Client.cc
+++ b/src/pd/Client.cc
@@ -508,21 +508,21 @@ bool Client::isClusterBootstrapped()
     return response.bootstrapped();
 }
 
-#define RESOURCE_CONTROL_FUNCTION_DEFINITION(FUNC_NAME, GRPC_METHOD, REQUEST_TYPE, RESPONSE_TYPE)                                                                   \
-    ::resource_manager::RESPONSE_TYPE Client::FUNC_NAME(const ::resource_manager::REQUEST_TYPE & request)                                                           \
-    {                                                                                                                                                               \
-        ::resource_manager::RESPONSE_TYPE response;                                                                                                                 \
-        grpc::ClientContext context;                                                                                                                                \
-        context.set_deadline(std::chrono::system_clock::now() + pd_timeout);                                                                                        \
-        auto status = leaderClient()->resource_manager_stub->GRPC_METHOD(&context, request, &response);                                                             \
-        if (!status.ok())                                                                                                                                           \
-        {                                                                                                                                                           \
-            std::string err_msg = ("resource manager grpc call failed: " #GRPC_METHOD ". " + std::to_string(status.error_code()) + ": " + status.error_message());  \
-            log->error(err_msg);                                                                                                                                    \
-            check_leader.store(true);                                                                                                                               \
-            throw Exception(err_msg, GRPCErrorCode);                                                                                                                \
-        }                                                                                                                                                           \
-        return response;                                                                                                                                            \
+#define RESOURCE_CONTROL_FUNCTION_DEFINITION(FUNC_NAME, GRPC_METHOD, REQUEST_TYPE, RESPONSE_TYPE)                                                                  \
+    ::resource_manager::RESPONSE_TYPE Client::FUNC_NAME(const ::resource_manager::REQUEST_TYPE & request)                                                          \
+    {                                                                                                                                                              \
+        ::resource_manager::RESPONSE_TYPE response;                                                                                                                \
+        grpc::ClientContext context;                                                                                                                               \
+        context.set_deadline(std::chrono::system_clock::now() + pd_timeout);                                                                                       \
+        auto status = leaderClient()->resource_manager_stub->GRPC_METHOD(&context, request, &response);                                                            \
+        if (!status.ok())                                                                                                                                          \
+        {                                                                                                                                                          \
+            std::string err_msg = ("resource manager grpc call failed: " #GRPC_METHOD ". " + std::to_string(status.error_code()) + ": " + status.error_message()); \
+            log->error(err_msg);                                                                                                                                   \
+            check_leader.store(true);                                                                                                                              \
+            throw Exception(err_msg, GRPCErrorCode);                                                                                                               \
+        }                                                                                                                                                          \
+        return response;                                                                                                                                           \
     }
 
 RESOURCE_CONTROL_FUNCTION_DEFINITION(listResourceGroups, ListResourceGroups, ListResourceGroupsRequest, ListResourceGroupsResponse)


### PR DESCRIPTION
1. use local variable instead of `shared_ptr` for rpc request and response
2. replace original implementation of `RpcTypeTraits` with a more elegant way