### PR TITLE
Make `ResponseIter` thread-safe

### DIFF
--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -97,6 +97,8 @@ struct BatchCopTask
     uint64_t store_id;
 };
 
+/// A iterator dedicated to send coprocessor(stream) request and receive responses.
+/// All functions are thread-safe.
 class ResponseIter
 {
 public:
@@ -131,7 +133,6 @@ public:
         , cluster(cluster_)
         , concurrency(concurrency_)
         , unfinished_thread(0)
-        , is_cancelled(false)
         , tiflash_label_filter(tiflash_label_filter_)
         , log(log_)
     {}
@@ -249,9 +250,10 @@ private:
     kv::MinCommitTSPushed min_commit_ts_pushed;
 
     std::atomic_int unfinished_thread;
-    std::atomic_bool is_cancelled;
 
+    std::atomic_bool is_cancelled = false;
     std::atomic_bool is_opened = false;
+
     const kv::LabelFilter tiflash_label_filter;
 
     Logger * log;

--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -172,6 +172,7 @@ public:
 
     std::pair<Result, bool> nonBlockingNext()
     {
+        assert(is_opened);
         Result res;
         switch (queue->tryPop(res))
         {
@@ -189,6 +190,7 @@ public:
 
     std::pair<Result, bool> next()
     {
+        assert(is_opened);
         Result res;
         switch (queue->pop(res))
         {

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -594,7 +594,7 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
     }
 
     bool is_first_resp = true;
-    while (!cancelled)
+    while (!is_cancelled)
     {
         resp = std::make_shared<::coprocessor::Response>();
         if (!reader->read(resp.get()))
@@ -641,7 +641,7 @@ void ResponseIter::handleTask(const CopTask & task)
     size_t idx = 0;
     while (idx < remain_tasks.size())
     {
-        if (cancelled)
+        if (is_cancelled)
             return;
         try
         {


### PR DESCRIPTION
make all functions of `ResponseIter` thread-safe