### PR TITLE
Clean useless header

### DIFF
--- a/include/pingcap/common/MPMCQueue.h
+++ b/include/pingcap/common/MPMCQueue.h
@@ -1,17 +1,3 @@
-// Copyright 2023 PingCAP, Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 #pragma once
 
 #include <cassert>


### PR DESCRIPTION
The file should follow the license of tikv but not pingcap. Which this repo define it by the file `LICENSE`