### PR TITLE
add resource group name for coprocessor request

### DIFF
--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -52,6 +52,7 @@ struct Request
     uint64_t start_ts;
     std::string data;
     int64_t schema_version;
+    std::string resource_group_name;
 };
 
 using RequestPtr = std::shared_ptr<Request>;

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -514,9 +514,11 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
     req.set_schema_ver(task.req->schema_version);
     req.set_data(task.req->data);
     req.set_is_cache_enabled(false);
+    auto * cop_req_context = req.mutable_context();
+    cop_req_context->mutable_resource_control_context()->set_resource_group_name(task.req->resource_group_name);
     for (auto ts : min_commit_ts_pushed.getTimestamps())
     {
-        req.mutable_context()->add_resolved_locks(ts);
+        cop_req_context->add_resolved_locks(ts);
     }
     for (const auto & range : task.ranges)
     {


### PR DESCRIPTION
For tiflash remote read, also need resource group name. So need to add resource group name when sending copr req.