### PR TITLE
some refine about coprocessor read

### DIFF
--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -217,7 +217,7 @@ private:
         {
             if (is_cancelled || meet_error)
             {
-                log->information("cop task exit because {}", is_cancelled ? " has been cancelled" : " already meet error");
+                log->information("cop task exit because {}", is_cancelled ? "has been cancelled" : "already meet error");
                 return;
             }
             std::unique_lock<std::mutex> lk(task_mutex);

--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -215,9 +215,9 @@ private:
         log->information("thread start.");
         while (true)
         {
-            if (is_cancelled)
+            if (is_cancelled || meet_error)
             {
-                log->information("cop task has been cancelled");
+                log->information("cop task exit because {}", is_cancelled ? " has been cancelled" : " already meet error");
                 return;
             }
             std::unique_lock<std::mutex> lk(task_mutex);
@@ -256,6 +256,7 @@ private:
     std::atomic_int unfinished_thread;
 
     std::atomic_bool is_cancelled = false;
+    std::atomic_bool meet_error = false;
     std::atomic_bool is_opened = false;
 
     const kv::LabelFilter tiflash_label_filter;

--- a/include/pingcap/kv/RegionClient.h
+++ b/include/pingcap/kv/RegionClient.h
@@ -80,7 +80,7 @@ struct RegionClient
             }
             if (resp->has_region_error())
             {
-                log->warning("region " + region_id.toString() + " find error: " + resp->region_error().message());
+                log->warning("region " + region_id.toString() + " find error: " + resp->region_error().DebugString());
                 onRegionError(bo, ctx, resp->region_error());
                 continue;
             }


### PR DESCRIPTION
1. exit earlier if some threads already meet error in `ResponseIter`
2. print useful information when meet error.