### PR TITLE
Remove deprecated split region param

### DIFF
--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -13,18 +13,18 @@ void Cluster::splitRegion(const std::string & split_key)
     auto loc = region_cache->locateKey(bo, split_key);
     RegionClient client(this, loc.region);
     kvrpcpb::SplitRegionRequest req;
-    req.set_split_key(split_key);
+    *req.mutable_split_keys()->Add() = split_key;
     kvrpcpb::SplitRegionResponse resp;
     client.sendReqToRegion<RPC_NAME(SplitRegion)>(bo, req, &resp);
     if (resp.has_region_error())
     {
         throw Exception(resp.region_error().message(), RegionUnavailable);
     }
-    auto lr = resp.left();
-    auto rr = resp.right();
     region_cache->dropRegion(loc.region);
-    region_cache->getRegionByID(bo, RegionVerID(lr.id(), lr.region_epoch().conf_ver(), lr.region_epoch().version()));
-    region_cache->getRegionByID(bo, RegionVerID(rr.id(), rr.region_epoch().conf_ver(), rr.region_epoch().version()));
+    for (const auto & r : resp.regions())
+    {
+        region_cache->getRegionByID(bo, RegionVerID{r.id(), r.region_epoch().conf_ver(), r.region_epoch().version()});
+    }
 }
 
 void Cluster::startBackgroundTasks()


### PR DESCRIPTION
Splitting region by only 1 key is deprecated. Split by multiple keys to suppress warnings.

Rely on https://github.com/tikv/mock-tikv/pull/12