### PR TITLE
handle rpc error when fetch cluster id from pd

### DIFF
--- a/src/pd/Client.cc
+++ b/src/pd/Client.cc
@@ -142,7 +142,13 @@ void Client::initClusterID()
                 log->warning("failed to get cluster id by :" + url + " retrying");
                 continue;
             }
+            if (resp.header().has_error())
+            {
+                log->warning("failed to init cluster id: " + resp.header().error().message());
+                continue;
+            }
             cluster_id = resp.header().cluster_id();
+            log->information("init cluster id done: " + std::to_string(cluster_id));
             return;
         }
         std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -495,6 +501,12 @@ bool Client::isClusterBootstrapped()
         std::string msg = ("check cluster bootstrapped failed: " + std::to_string(status.error_code()) + ": " + status.error_message());
         log->warning(msg);
         check_leader.store(true);
+        return false;
+    }
+
+    if (!response.has_header())
+    {
+        log->warning("check cluster bootstrapped failed: header of IsBootstrappedResponse not setup");
         return false;
     }
 


### PR DESCRIPTION
close: https://github.com/tikv/client-c/issues/169

When init cluster id, should also check error in rpc response, otherwise cluster id maybe zero mistakely.

Because PD will not set cluster id if got error, instead it put err msg in rpc response.Error. check [here](https://github.com/tikv/client-c/blob/master/src/pd/Client.cc#L145) and [here](https://github.com/tikv/pd/blob/master/server/grpc_service.go#L471)
