### PR TITLE
Compatible with txn file in resolveLocks

### DIFF
--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -63,6 +63,7 @@ struct Lock
     bool use_async_commit;
     uint64_t lock_for_update_ts;
     uint64_t min_commit_ts;
+    bool is_txn_file;
 
     explicit Lock(const ::kvrpcpb::LockInfo & l)
         : key(l.key())
@@ -74,6 +75,7 @@ struct Lock
         , use_async_commit(l.use_async_commit())
         , lock_for_update_ts(l.lock_for_update_ts())
         , min_commit_ts(l.min_commit_ts())
+        , is_txn_file(l.is_txn_file())
     {}
 
     std::string toDebugString() const;
@@ -287,7 +289,7 @@ private:
     TxnStatus getTxnStatusFromLock(Backoffer & bo, LockPtr lock, uint64_t caller_start_ts, bool force_sync_commit);
 
 
-    TxnStatus getTxnStatus(Backoffer & bo, uint64_t txn_id, const std::string & primary, uint64_t caller_start_ts, uint64_t current_ts, bool rollback_if_not_exists, bool force_sync_commit);
+    TxnStatus getTxnStatus(Backoffer & bo, uint64_t txn_id, const std::string & primary, uint64_t caller_start_ts, uint64_t current_ts, bool rollback_if_not_exists, bool force_sync_commit, bool is_txn_file);
 
     Cluster * cluster;
     std::shared_mutex mu;


### PR DESCRIPTION
1. Add `is_txn_file` to `resolveLock` and `CheckTxnStatus` request if it has `is_txn_file` in `LockInfo`.
2. Update kvproto to support txn file.