### PR TITLE
Enhance the logging when encounter lock issue

### DIFF
--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -624,7 +624,7 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
         if (before_expired > 0)
         {
             log->information("get lock and sleep for a while, sleep time is " + std::to_string(before_expired) + "ms.");
-            bo.backoffWithMaxSleep(kv::boTxnLockFast, before_expired, Exception(locked.DebugString(), ErrorCodes::LockError));
+            bo.backoffWithMaxSleep(kv::boTxnLockFast, before_expired, Exception("encounter lock, region_id=" + task.region_id.toString() + " " + locked.DebugString(), ErrorCodes::LockError));
         }
         return buildCopTasks(bo, cluster, task.ranges, task.req, task.store_type, task.keyspace_id, task.connection_id, task.connection_alias, log, task.meta_data, task.before_send);
     };
@@ -727,10 +727,10 @@ void ResponseIter::handleTask(const CopTask & task)
     {
         if (is_cancelled || meet_error)
             return;
+        const auto & current_task = remain_tasks[idx];
+        auto & bo = bo_maps.try_emplace(current_task.region_id.id, kv::copNextMaxBackoff).first->second;
         try
         {
-            auto & current_task = remain_tasks[idx];
-            auto & bo = bo_maps.try_emplace(current_task.region_id.id, kv::copNextMaxBackoff).first->second;
             auto new_tasks = handleTaskImpl<is_stream>(bo, current_task);
             if (!new_tasks.empty())
             {
@@ -739,7 +739,7 @@ void ResponseIter::handleTask(const CopTask & task)
         }
         catch (const pingcap::Exception & e)
         {
-            log->error("coprocessor meets error, error message: " + e.displayText() + ", error code: " + std::to_string(e.code()));
+            log->error("coprocessor meets error, error_message=" + e.displayText() + " error_code=" + std::to_string(e.code()) + " region_id=" + current_task.region_id.toString());
             queue->push(Result(e));
             meet_error = true;
             break;

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <cstdint>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace pingcap
@@ -738,7 +739,7 @@ void ResponseIter::handleTask(const CopTask & task)
         }
         catch (const pingcap::Exception & e)
         {
-            log->error("coprocessor meets error, error message: {}, error code: {}", e.displayText(), e.code());
+            log->error("coprocessor meets error, error message: " + e.displayText() + ", error code: " + std::to_string(e.code()));
             queue->push(Result(e));
             meet_error = true;
             break;

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -623,7 +623,9 @@ std::vector<CopTask> ResponseIter::handleTaskImpl(kv::Backoffer & bo, const CopT
         }
         if (before_expired > 0)
         {
-            log->information("get lock and sleep for a while, sleep time is " + std::to_string(before_expired) + "ms.");
+            log->information("encounter lock and sleep for a while, region_id=" + task.region_id.toString() + //
+                             " req_start_ts=" + std::to_string(task.req->start_ts) + " lock_version=" + std::to_string(lock->txn_id) + //
+                             " sleep time is " + std::to_string(before_expired) + "ms.");
             bo.backoffWithMaxSleep(kv::boTxnLockFast, before_expired, Exception("encounter lock, region_id=" + task.region_id.toString() + " " + locked.DebugString(), ErrorCodes::LockError));
         }
         return buildCopTasks(bo, cluster, task.ranges, task.req, task.store_type, task.keyspace_id, task.connection_id, task.connection_alias, log, task.meta_data, task.before_send);

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -101,7 +101,7 @@ int64_t LockResolver::resolveLocks(
                     return before_txn_expired.value();
                 }
             }
-            else
+            else // status.ttl != 0
             {
                 auto before_txn_expired_time = cluster->oracle->untilExpired(lock->txn_id, status.ttl);
                 before_txn_expired.update(before_txn_expired_time);

--- a/src/kv/Snapshot.cc
+++ b/src/kv/Snapshot.cc
@@ -48,7 +48,7 @@ kvrpcpb::MvccInfo Snapshot::mvccGet(Backoffer & bo, const std::string & key)
         if (!response.error().empty())
         {
             Logger * log(&Logger::get("Snapshot::mvccGet"));
-            log->error("reponse error is {}", response.error());
+            log->error("reponse error is " + response.error());
             continue;
         }
         return response.info();


### PR DESCRIPTION
some logging is not correctly format to output

```
tiflash-1/server.log:[2024/12/03 08:26:39.803 +08:00] [ERROR] [<unknown>] ["coprocessor meets error, error message: {}, error code: {}"] [source="MPP<gather_id:1, query_ts:1733185578514561761, local_query_id:23880, server_id:1855, start_ts:454344200276410379,task_id:1> pingcap/coprocessor"] [thread_id=3853]
tiflash-1/server.log:[2024/12/03 08:26:39.804 +08:00] [INFO] [<unknown>] ["cop task exit because already meet error"] [source="MPP<gather_id:1, query_ts:1733185578514561761, local_query_id:23880, server_id:1855, start_ts:454344200276410379,task_id:1> pingcap/coprocessor"] [thread_id=3853]
tiflash-1/server.log:[2024/12/03 08:26:39.804 +08:00] [WARN] [CoprocessorReaderSourceOp.cpp:78] ["coprocessor reader meets error: primary_lock: \"t\\200\\000\\000\\000\\000\\000\\000r_r\\003\\200\\000\\000\\000\\000\\000\\000P\\003\\200\\000\\000\\000\\000\\000\\000\\003\"\nlock_version: 454344200119123975\nkey: \"t\\200\\000\\000\\000\\000\\000\\000|_r\\003\\200\\000\\000\\000\\000\\000\\000P\\003\\200\\000\\000\\000\\000\\000\\000\\003\\003\\200\\000\\000\\000\\000\\000\\017\\365\\003\\200\\000\\000\\000\\000\\000\\000\\001\"\nlock_ttl: 20041\ntxn_size: 6\nlock_for_update_ts: 454344200119123975\nuse_async_commit: true\nmin_commit_ts: 454344200132231183\n"] [source="MPP<gather_id:1, query_ts:1733185578514561761, local_query_id:23880, server_id:1855, start_ts:454344200276410379,task_id:1>"] [thread_id=13]
tiflash-1/server.log:[2024/12/03 08:26:39.805 +08:00] [WARN] [Task.cpp:128] ["error occurred and cancel the query"] [source="MPP<gather_id:1, query_ts:1733185578514561761, local_query_id:23880, server_id:1855, start_ts:454344200276410379,task_id:1> 1"] [thread_id=13]
```