### PR TITLE
Change default timeout of cop task

### DIFF
--- a/include/pingcap/kv/Backoff.h
+++ b/include/pingcap/kv/Backoff.h
@@ -99,7 +99,7 @@ constexpr int commitMaxBackoff = 41000;
 constexpr int splitRegionBackoff = 20000;
 constexpr int cleanupMaxBackoff = 20000;
 constexpr int copBuildTaskMaxBackoff = 5000;
-constexpr int copNextMaxBackoff = 20000;
+constexpr int copNextMaxBackoff = 60000;
 constexpr int pessimisticLockMaxBackoff = 20000;
 
 using BackoffPtr = std::shared_ptr<Backoff>;


### PR DESCRIPTION
change default timeout of cop task to 60s as client-go does(https://github.com/tikv/client-go/blob/e7894a7b27ba6adbff61d69850883638c3b5345a/config/client.go#L191).