### PR TITLE
disable update region cache periodically for unit test

### DIFF
--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -65,7 +65,8 @@ struct Cluster
     ~Cluster()
     {
         mpp_prober->stop();
-        region_cache->stop();
+        if (region_cache)
+            region_cache->stop();
         thread_pool->stop();
     }
 

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -31,11 +31,16 @@ void Cluster::startBackgroundTasks()
 {
     thread_pool->start();
     thread_pool->enqueue([this] {
-        this->mpp_prober->run();
+        mpp_prober->run();
     });
-    thread_pool->enqueue([this] {
-        this->region_cache->updateCachePeriodically();
-    });
+    if (region_cache)
+    {
+        // region_cache may not be inited if pd addr is not setup.
+        // So skip update region cache periodically.
+        thread_pool->enqueue([this] {
+            region_cache->updateCachePeriodically();
+        });
+    }
 }
 
 } // namespace kv


### PR DESCRIPTION
tiflash will not init region cache when running gtests.
so we need to disable update region cache periodically in this situation.