### PR TITLE
refine buildBathCopTask retry log when there is no alive store

### DIFF
--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -132,7 +132,6 @@ struct Region
 
 using RegionPtr = std::shared_ptr<Region>;
 using LabelFilter = bool (*)(const std::map<std::string, std::string> &);
-using StoreFilter = std::function<bool(uint64_t)>;
 
 struct KeyLocation
 {
@@ -157,15 +156,13 @@ struct RPCContext
     metapb::Peer peer;
     Store store;
     std::string addr;
-    std::vector<uint64_t> all_stores;
 
-    RPCContext(const RegionVerID & region_, const metapb::Region & meta_, const metapb::Peer & peer_, const Store & store_, const std::string & addr_, const std::vector<uint64_t> & all_stores_)
+    RPCContext(const RegionVerID & region_, const metapb::Region & meta_, const metapb::Peer & peer_, const Store & store_, const std::string & addr_)
         : region(region_)
         , meta(meta_)
         , peer(peer_)
         , store(store_)
         , addr(addr_)
-        , all_stores(all_stores_)
     {}
 
     std::string toString() const
@@ -187,13 +184,7 @@ public:
         , log(&Logger::get("pingcap.tikv"))
     {}
 
-    RPCContextPtr getRPCContext(Backoffer & bo,
-            const RegionVerID & id,
-            StoreType store_type,
-            bool load_balance,
-            const LabelFilter & tiflash_label_filter,
-            const std::unordered_set<uint64_t> * store_id_blocklist = nullptr,
-            std::map<uint64_t, kv::Store> * alive_tiflash_stores = nullptr);
+    RPCContextPtr getRPCContext(Backoffer & bo, const RegionVerID & id, StoreType store_type, bool load_balance, const LabelFilter & tiflash_label_filter, const std::unordered_set<uint64_t> * store_id_blocklist = nullptr);
 
     bool updateLeader(const RegionVerID & region_id, const metapb::Peer & leader);
 
@@ -212,16 +203,11 @@ public:
     RegionPtr getRegionByID(Backoffer & bo, const RegionVerID & id);
 
     Store getStore(Backoffer & bo, uint64_t id);
-    void forceReloadAllStores();
 
     // Return values:
     // 1. all stores of peers of this region
     // 2. stores of non pending peers of this region
-    std::pair<std::vector<uint64_t>, std::vector<uint64_t>> getTiFlashStoresByFilter(
-            Backoffer & bo,
-            const RegionPtr & cached_region,
-            const LabelFilter & label_filter,
-            const std::unordered_set<uint64_t> * store_id_blocklist = nullptr);
+    std::pair<std::vector<uint64_t>, std::vector<uint64_t>> getAllValidTiFlashStores(Backoffer & bo, const RegionVerID & region_id, const Store & current_store, const LabelFilter & label_filter, const std::unordered_set<uint64_t> * store_id_blocklist = nullptr);
 
     std::pair<std::unordered_map<RegionVerID, std::vector<std::string>>, RegionVerID>
     groupKeysByRegion(Backoffer & bo,
@@ -238,12 +224,11 @@ private:
 
     metapb::Store loadStore(Backoffer & bo, uint64_t id);
 
-    Store reloadStore(const metapb::Store & store);
+    Store reloadStoreWithoutLock(const metapb::Store & store);
 
     RegionPtr searchCachedRegion(const std::string & key);
 
     std::vector<metapb::Peer> selectTiFlashPeers(Backoffer & bo, const metapb::Region & meta, const LabelFilter & label_filter);
-    std::vector<metapb::Peer> selectPeers(Backoffer & bo, const metapb::Region & meta, const StoreFilter & store_filter);
 
     void insertRegionToCache(RegionPtr region);
 

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -22,12 +22,12 @@ enum class StoreType
 
 struct Store
 {
-    const uint64_t id;
-    const std::string addr;
-    const std::string peer_addr;
-    const std::map<std::string, std::string> labels;
-    const StoreType store_type;
-    const ::metapb::StoreState state;
+    uint64_t id;
+    std::string addr;
+    std::string peer_addr;
+    std::map<std::string, std::string> labels;
+    StoreType store_type;
+    ::metapb::StoreState state;
 
     Store(uint64_t id_, const std::string & addr_, const std::string & peer_addr_, const std::map<std::string, std::string> & labels_, StoreType store_type_, const ::metapb::StoreState state_)
         : id(id_)
@@ -203,6 +203,7 @@ public:
     RegionPtr getRegionByID(Backoffer & bo, const RegionVerID & id);
 
     Store getStore(Backoffer & bo, uint64_t id);
+    void forceReloadAllStores();
 
     // Return values:
     // 1. all stores of peers of this region

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -29,7 +29,9 @@ struct Store
     StoreType store_type;
     ::metapb::StoreState state;
 
-    Store(uint64_t id_, const std::string & addr_, const std::string & peer_addr_, const std::map<std::string, std::string> & labels_, StoreType store_type_, const ::metapb::StoreState state_)
+    Store(uint64_t id_, const std::string & addr_, const std::string & peer_addr_,
+        const std::map<std::string, std::string> & labels_, StoreType store_type_,
+        const ::metapb::StoreState state_)
         : id(id_)
         , addr(addr_)
         , peer_addr(peer_addr_)
@@ -132,6 +134,7 @@ struct Region
 
 using RegionPtr = std::shared_ptr<Region>;
 using LabelFilter = bool (*)(const std::map<std::string, std::string> &);
+using StoreFilter = std::function<bool(uint64_t)>;
 
 struct KeyLocation
 {
@@ -184,7 +187,12 @@ public:
         , log(&Logger::get("pingcap.tikv"))
     {}
 
-    RPCContextPtr getRPCContext(Backoffer & bo, const RegionVerID & id, StoreType store_type, bool load_balance, const LabelFilter & tiflash_label_filter, const std::unordered_set<uint64_t> * store_id_blocklist = nullptr);
+    RPCContextPtr getRPCContext(Backoffer & bo,
+            const RegionVerID & id,
+            StoreType store_type,
+            bool load_balance,
+            const LabelFilter & tiflash_label_filter,
+            const std::unordered_set<uint64_t> * store_id_blocklist = nullptr);
 
     bool updateLeader(const RegionVerID & region_id, const metapb::Peer & leader);
 
@@ -206,9 +214,13 @@ public:
     void forceReloadAllStores();
 
     // Return values:
-    // 1. all stores of peers of this region
-    // 2. stores of non pending peers of this region
-    std::pair<std::vector<uint64_t>, std::vector<uint64_t>> getAllValidTiFlashStores(Backoffer & bo, const RegionVerID & region_id, const Store & current_store, const LabelFilter & label_filter, const std::unordered_set<uint64_t> * store_id_blocklist = nullptr);
+    // 1. all stores of this region.
+    // 2. stores of non pending peers of this region.
+    std::pair<std::vector<uint64_t>, std::vector<uint64_t>> getAllValidTiFlashStores(Backoffer & bo,
+            const RegionVerID & region_id,
+            const Store & current_store,
+            const LabelFilter & label_filter,
+            const std::unordered_set<uint64_t> * store_id_blocklist = nullptr);
 
     std::pair<std::unordered_map<RegionVerID, std::vector<std::string>>, RegionVerID>
     groupKeysByRegion(Backoffer & bo,

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -215,6 +215,36 @@ public:
 
     std::map<uint64_t, Store> getAllTiFlashStores(const LabelFilter & label_filter, bool exclude_tombstone);
 
+    void updateCachePeriodically()
+    {
+        while (!stopped.load())
+        {
+            // TODO: Also update region cache periodically.
+            try
+            {
+                forceReloadAllStores();
+            }
+            catch (...)
+            {
+                log->warning(getCurrentExceptionMsg("failed to reload all stores periodically: "));
+            }
+
+            {
+                std::unique_lock lock(update_cache_mu);
+                // Update store cache every 2 mins.
+                update_cache_cv.wait_for(lock, std::chrono::minutes(2), [this]() {
+                    return stopped.load();
+                });
+            }
+        }
+    }
+
+    void stop()
+    {
+        stopped.store(true);
+        std::lock_guard lock(update_cache_mu);
+        update_cache_cv.notify_all();
+    }
 private:
     RegionPtr loadRegionByKey(Backoffer & bo, const std::string & key);
 
@@ -254,6 +284,10 @@ private:
     const std::string tiflash_engine_value;
 
     Logger * log;
+
+    std::atomic<bool> stopped = false;
+    std::mutex update_cache_mu;
+    std::condition_variable update_cache_cv;
 };
 
 using RegionCachePtr = std::unique_ptr<RegionCache>;

--- a/include/pingcap/kv/RegionCache.h
+++ b/include/pingcap/kv/RegionCache.h
@@ -30,8 +30,8 @@ struct Store
     ::metapb::StoreState state;
 
     Store(uint64_t id_, const std::string & addr_, const std::string & peer_addr_,
-        const std::map<std::string, std::string> & labels_, StoreType store_type_,
-        const ::metapb::StoreState state_)
+            const std::map<std::string, std::string> & labels_, StoreType store_type_,
+            const ::metapb::StoreState state_)
         : id(id_)
         , addr(addr_)
         , peer_addr(peer_addr_)

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -401,7 +401,7 @@ std::vector<BatchCopTask> balanceBatchCopTasks(
     return ret;
 }
 
-// Return true if need retry. And invalid regions will be dropped and retry.
+// Return true and invalid region cache if one region has no alive store.
 bool checkAliveStores(
         const std::vector<CopTask> & cop_tasks,
         const std::vector<std::vector<uint64_t>> & all_used_tiflash_store_ids,

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -138,7 +138,7 @@ std::unordered_map<uint64_t, kv::Store> filterAliveStores(kv::Cluster * cluster,
 }
 
 std::vector<BatchCopTask> balanceBatchCopTasks(
-        const std::map<uint64_t, kv::Store> * alive_tiflash_stores,
+        const std::unordered_map<uint64_t, kv::Store> * alive_tiflash_stores,
         const std::vector<BatchCopTask> & original_tasks,
         bool is_mpp,
         Poco::Logger * log,
@@ -487,12 +487,6 @@ std::vector<BatchCopTask> buildBatchCopTasks(
     auto & cache = cluster->region_cache;
 
     assert(physical_table_ids.size() == ranges_for_each_physical_table.size());
-    auto stores_to_str = [](const std::string_view prefix, const std::map<uint64_t, kv::Store> & stores) -> std::string {
-        std::string msg(prefix);
-        for (const auto & ele : stores)
-            msg += " " + std::to_string(ele.first) + ":" + ele.second.addr;
-        return msg;
-    };
     const bool filter_alive_tiflash_stores = (store_type == kv::StoreType::TiFlash);
 
     while (true) // for `need_retry`

--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -588,7 +588,6 @@ std::vector<BatchCopTask> buildBatchCopTasks(
         std::unordered_map<uint64_t, kv::Store> alive_tiflash_stores;
         if (filter_alive_tiflash_stores)
         {
-            // auto tiflash_stores = cache->getAllTiFlashStores(label_filter, /*exclude_tombstone =*/true);
             std::unordered_map<uint64_t, kv::Store> all_used_tiflash_stores;
             all_used_tiflash_stores.reserve(all_used_tiflash_store_ids_set.size());
             for (const auto & store_id : all_used_tiflash_store_ids_set)

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -448,12 +448,13 @@ std::map<uint64_t, Store> RegionCache::getAllTiFlashStores(const LabelFilter & l
     }
     return ret_stores;
 }
+
 void RegionCache::forceReloadAllStores()
 {
     const auto all_stores = pd_client->getAllStores(/*exclude_tombstone=*/false);
     std::lock_guard<std::mutex> lock(store_mutex);
     for (const auto & store_pb : all_stores)
-        reloadStore(store_pb);
+        reloadStoreWithoutLock(store_pb);
 }
 
 bool hasLabel(const std::map<std::string, std::string> & labels, const std::string & key, const std::string & val)

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -9,7 +9,12 @@ namespace kv
 {
 // load_balance is an option, becase if store fail, it may cause batchCop fail.
 // For now, label_filter only works for tiflash.
-RPCContextPtr RegionCache::getRPCContext(Backoffer & bo, const RegionVerID & id, const StoreType store_type, bool load_balance, const LabelFilter & tiflash_label_filter, const std::unordered_set<uint64_t> * store_id_blocklist)
+RPCContextPtr RegionCache::getRPCContext(Backoffer & bo,
+        const RegionVerID & id,
+        const StoreType store_type,
+        bool load_balance,
+        const LabelFilter & tiflash_label_filter,
+        const std::unordered_set<uint64_t> * store_id_blocklist)
 {
     for (;;)
     {
@@ -56,6 +61,7 @@ RPCContextPtr RegionCache::getRPCContext(Backoffer & bo, const RegionVerID & id,
             }
             if (store_id_blocklist && store_id_blocklist->count(store.id) > 0)
             {
+                log->warning("blocklist remove peer for region: " + id.toString() + std::string(", store: ") + std::to_string(store.id));
                 continue;
             }
             if (store_type == StoreType::TiFlash)

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -448,6 +448,13 @@ std::map<uint64_t, Store> RegionCache::getAllTiFlashStores(const LabelFilter & l
     }
     return ret_stores;
 }
+void RegionCache::forceReloadAllStores()
+{
+    const auto all_stores = pd_client->getAllStores(/*exclude_tombstone=*/false);
+    std::lock_guard<std::mutex> lock(store_mutex);
+    for (const auto & store_pb : all_stores)
+        reloadStore(store_pb);
+}
 
 bool hasLabel(const std::map<std::string, std::string> & labels, const std::string & key, const std::string & val)
 {

--- a/src/kv/RegionCache.cc
+++ b/src/kv/RegionCache.cc
@@ -9,13 +9,7 @@ namespace kv
 {
 // load_balance is an option, becase if store fail, it may cause batchCop fail.
 // For now, label_filter only works for tiflash.
-RPCContextPtr RegionCache::getRPCContext(Backoffer & bo,
-        const RegionVerID & id,
-        const StoreType store_type,
-        bool load_balance,
-        const LabelFilter & tiflash_label_filter,
-        const std::unordered_set<uint64_t> * store_id_blocklist,
-        std::map<uint64_t, kv::Store> * alive_tiflash_stores)
+RPCContextPtr RegionCache::getRPCContext(Backoffer & bo, const RegionVerID & id, const StoreType store_type, bool load_balance, const LabelFilter & tiflash_label_filter, const std::unordered_set<uint64_t> * store_id_blocklist)
 {
     for (;;)
     {
@@ -26,68 +20,19 @@ RPCContextPtr RegionCache::getRPCContext(Backoffer & bo,
         const auto & meta = region->meta;
         std::vector<metapb::Peer> peers;
         size_t start_index = 0;
-        std::vector<uint64_t> rpc_ctx_all_stores;
         if (store_type == StoreType::TiKV)
         {
-            // Only access to the leader
-            const auto & leader = region->leader_peer;
-            if (store_id_blocklist == nullptr ||
-                    store_id_blocklist->find(leader.store_id()) == store_id_blocklist->end())
-            {
-                peers.push_back(leader);
-                rpc_ctx_all_stores.push_back(leader.store_id());
-            }
-            else
-            {
-                log->warning("blocklist remove leader peer for region: " + id.toString());
-            }
+            // only access to the leader
+            peers.push_back(region->leader_peer);
         }
         else
         {
-            std::vector<uint64_t> non_pending_stores;
-            std::tie(rpc_ctx_all_stores, non_pending_stores) = getTiFlashStoresByFilter(bo, region, tiflash_label_filter, store_id_blocklist);
-
-            // Pending stores exist for this region, need to refresh region cache until this region is ok.
-            if (rpc_ctx_all_stores.size() != non_pending_stores.size())
-                dropRegion(id);
-
-            if (alive_tiflash_stores != nullptr)
-            {
-                auto filter_alive_tiflash_stores = [alive_tiflash_stores](const std::vector<uint64_t> & stores) {
-                    std::vector<uint64_t> tmp_filter_stores;
-                    tmp_filter_stores.reserve(stores.size());
-                    for (const auto id : stores)
-                    {
-                        if (alive_tiflash_stores->find(id) != alive_tiflash_stores->end())
-                            tmp_filter_stores.push_back(id);
-                    }
-                    return tmp_filter_stores;
-                };
-                rpc_ctx_all_stores = filter_alive_tiflash_stores(rpc_ctx_all_stores);
-                non_pending_stores = filter_alive_tiflash_stores(non_pending_stores);
-            }
-
-            // Use non_pending_stores to dispatch this task by default.
-            // If all stores are in pending state, we use `rpc_ctx_all_stores` as fallback.
-            if (!non_pending_stores.empty())
-                rpc_ctx_all_stores = non_pending_stores;
-
-            if (!rpc_ctx_all_stores.empty())
-            {
-                peers = selectPeers(bo, meta, [&rpc_ctx_all_stores](uint64_t cur_store_id) {
-                            for (const auto id : rpc_ctx_all_stores)
-                            {
-                                if (id == cur_store_id)
-                                    return true;
-                            }
-                            return false;
-                        });
-
-                if (load_balance)
-                    start_index = ++region->work_tiflash_peer_idx;
-                else
-                    start_index = region->work_tiflash_peer_idx;
-            }
+            // can access to all tiflash peers
+            peers = selectTiFlashPeers(bo, meta, tiflash_label_filter);
+            if (load_balance)
+                start_index = ++region->work_tiflash_peer_idx;
+            else
+                start_index = region->work_tiflash_peer_idx;
         }
 
         const size_t peer_size = peers.size();
@@ -109,12 +54,16 @@ RPCContextPtr RegionCache::getRPCContext(Backoffer & bo,
                                      StoreNotReady));
                 continue;
             }
+            if (store_id_blocklist && store_id_blocklist->count(store.id) > 0)
+            {
+                continue;
+            }
             if (store_type == StoreType::TiFlash)
             {
                 // set the index for next access in order to balance the workload among all tiflash peers
                 region->work_tiflash_peer_idx.store(peer_index);
             }
-            return std::make_shared<RPCContext>(id, meta, peer, store, store.addr, rpc_ctx_all_stores);
+            return std::make_shared<RPCContext>(id, meta, peer, store, store.addr);
         }
         dropRegion(id);
         bo.backoff(boRegionMiss, Exception("region miss, region id is: " + std::to_string(id.id), RegionUnavailable));
@@ -160,17 +109,6 @@ KeyLocation RegionCache::locateKey(Backoffer & bo, const std::string & key)
     insertRegionToCache(region);
 
     return KeyLocation(region->verID(), region->startKey(), region->endKey());
-}
-
-std::vector<metapb::Peer> RegionCache::selectPeers(Backoffer & bo, const metapb::Region & meta, const StoreFilter & store_filter)
-{
-    std::vector<metapb::Peer> res_peers;
-    for (const auto & peer : meta.peers())
-    {
-        if (const Store & store = getStore(bo, peer.store_id()); store_filter(store.id))
-            res_peers.push_back(peer);
-    }
-    return res_peers;
 }
 
 // select all tiflash peers
@@ -273,7 +211,7 @@ metapb::Store RegionCache::loadStore(Backoffer & bo, uint64_t id)
     }
 }
 
-Store RegionCache::reloadStore(const metapb::Store & store)
+Store RegionCache::reloadStoreWithoutLock(const metapb::Store & store)
 {
     auto id = store.id();
     std::map<std::string, std::string> labels;
@@ -288,8 +226,8 @@ Store RegionCache::reloadStore(const metapb::Store & store)
             store_type = StoreType::TiFlash;
         }
     }
-    auto it = stores.emplace(id, Store(id, store.address(), store.peer_address(), labels, store_type, store.state()));
-    return it.first->second;
+    auto res = stores.insert_or_assign(id, Store(id, store.address(), store.peer_address(), labels, store_type, store.state()));
+    return res.first->second;
 }
 
 Store RegionCache::getStore(Backoffer & bo, uint64_t id)
@@ -301,32 +239,12 @@ Store RegionCache::getStore(Backoffer & bo, uint64_t id)
         return (it->second);
     }
     auto store = loadStore(bo, id);
-    return reloadStore(store);
+    return reloadStoreWithoutLock(store);
 }
 
-void RegionCache::forceReloadAllStores()
+std::pair<std::vector<uint64_t>, std::vector<uint64_t>> RegionCache::getAllValidTiFlashStores(Backoffer & bo, const RegionVerID & region_id, const Store & current_store, const LabelFilter & label_filter, const std::unordered_set<uint64_t> * store_id_blocklist)
 {
-    const auto all_stores = pd_client->getAllStores(/*exclude_tombstone=*/false);
-    std::lock_guard<std::mutex> lock(store_mutex);
-    for (const auto & store_pb : all_stores)
-        reloadStore(store_pb);
-}
-
-std::pair<std::vector<uint64_t>, std::vector<uint64_t>> RegionCache::getTiFlashStoresByFilter(
-        Backoffer & bo,
-        const RegionPtr & cached_region,
-        const LabelFilter & label_filter,
-        const std::unordered_set<uint64_t> * store_id_blocklist)
-{
-    std::vector<uint64_t> all_stores;
-    std::vector<uint64_t> non_pending_stores;
-    if (cached_region == nullptr)
-        return std::make_pair(all_stores, non_pending_stores);
-
-    auto remove_blocklist = [](const std::unordered_set<uint64_t> * store_id_blocklist,
-            std::vector<uint64_t> & stores,
-            const RegionVerID & region_id,
-            Logger * log) {
+    auto remove_blocklist = [](const std::unordered_set<uint64_t> * store_id_blocklist, std::vector<uint64_t> & stores, const RegionVerID & region_id, Logger * log) {
         if (store_id_blocklist != nullptr)
         {
             auto origin_size = stores.size();
@@ -341,9 +259,18 @@ std::pair<std::vector<uint64_t>, std::vector<uint64_t>> RegionCache::getTiFlashS
             }
         }
     };
+    std::vector<uint64_t> all_stores;
+    std::vector<uint64_t> non_pending_stores;
+    RegionPtr cached_region = getRegionByIDFromCache(region_id);
+    if (cached_region == nullptr)
+    {
+        all_stores.emplace_back(current_store.id);
+        remove_blocklist(store_id_blocklist, all_stores, region_id, log);
+        return std::make_pair(all_stores, non_pending_stores);
+    }
 
     // Get others tiflash store ids
-    // TODO: Add TTL support for region cache, just like client-go.
+    // TODO: client-go also check region cache TTL.
     auto peers = selectTiFlashPeers(bo, cached_region->meta, label_filter);
     for (const auto & peer : peers)
     {
@@ -361,8 +288,8 @@ std::pair<std::vector<uint64_t>, std::vector<uint64_t>> RegionCache::getTiFlashS
             non_pending_stores.emplace_back(peer.store_id());
     }
 
-    remove_blocklist(store_id_blocklist, all_stores, cached_region->verID(), log);
-    remove_blocklist(store_id_blocklist, non_pending_stores, cached_region->verID(), nullptr);
+    remove_blocklist(store_id_blocklist, all_stores, region_id, log);
+    remove_blocklist(store_id_blocklist, non_pending_stores, region_id, nullptr);
     return std::make_pair(all_stores, non_pending_stores);
 }
 


### PR DESCRIPTION
1. revert  https://github.com/tikv/client-c/pull/203 `src/kv/RegionCache.cc` and `include/pingcap/kv/RegionCache.h` 
2. port the logic of https://github.com/pingcap/tidb/pull/62085 in `buildBatchCopTasksCore`, mainly `checkAliveStore()`

before:
1. before build batchCopTask, filter alive tiflash and reload all stores if there is no alive tiflash
2. filter alive tiflash when calling getRPCContext(), so all stores in `rpc_context->all_stores` are alive

but the `rpc_context->all_stores` canbe empty if there is no alive store for this region, and query will fail.

after:
1. before build batchCopTask, ilter alive tiflash and force reload all stores if there is no alive tiflash
2. for each region, we count if there is at least one alive tiflash store, if not, we invalid region cache and retry.

