### PR TITLE
fix mac build

### DIFF
--- a/src/coprocessor/Client.cc
+++ b/src/coprocessor/Client.cc
@@ -579,7 +579,7 @@ std::vector<BatchCopTask> buildBatchCopTasks(
                     .partition_index = cop_task.partition_index,
                 });
             }
-            min_replica_num = std::min(min_replica_num, all_stores.size());
+            min_replica_num = std::min(min_replica_num, static_cast<uint64_t>(all_stores.size()));
             all_used_tiflash_store_ids.push_back(all_stores);
             for (const auto & store : all_stores)
                 all_used_tiflash_store_ids_set.insert(store);


### PR DESCRIPTION
```
source/tiflash/contrib/client-c/src/coprocessor/Client.cc
    ^[[44m[📡 STDOUT] ^[[49m/Users/pingcap/workspace/bp-tiflash-release-darwin-amd64-4cnsp-build-binaries/source/tiflash/contrib/client-c/src/coprocessor/Client.cc:582:31: error: no matching function for call to 'min'
    ^[[44m[📡 STDOUT] ^[[49m  582 |             min_replica_num = std::min(min_replica_num, all_stores.size());
    ^[[44m[📡 STDOUT] ^[[49m      |                               ^~~~~~~~
    ^[[44m[📡 STDOUT] ^[[49m/usr/local/opt/llvm@17/bin/../include/c++/v1/__algorithm/min.h:40:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('uint64_t' (aka 'unsigned long long') vs. 'size_type' (aka    'unsigned long'))
    ^[[44m[📡 STDOUT] ^[[49m   40 | min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b)
    ^[[44m[📡 STDOUT] ^[[49m      | ^
    ^[[44m[📡 STDOUT] ^[[49m/usr/local/opt/llvm@17/bin/../include/c++/v1/__algorithm/min.h:51:1: note: candidate template ignored: could not match 'initializer_list<_Tp>' against 'uint64_t' (aka 'unsigned long long')
    ^[[44m[📡 STDOUT] ^[[49m   51 | min(initializer_list<_Tp> __t, _Compare __comp)
    ^[[44m[📡 STDOUT] ^[[49m      | ^
    ^[[44m[📡 STDOUT] ^[[49m/usr/local/opt/llvm@17/bin/../include/c++/v1/__algorithm/min.h:60:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
    ^[[44m[📡 STDOUT] ^[[49m   60 | min(initializer_list<_Tp> __t)
    ^[[44m[📡 STDOUT] ^[[49m      | ^   ~~~~~~~~~~~~~~~~~~~~~~~~~
    ^[[44m[📡 STDOUT] ^[[49m/usr/local/opt/llvm@17/bin/../include/c++/v1/__algorithm/min.h:31:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
    ^[[44m[📡 STDOUT] ^[[49m   31 | min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b, _Compare __comp)
    ^[[44m[📡 STDOUT] ^[[49m      | ^                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ^[[44m[📡 STDOUT] ^[[49m1 error generated.
    ^[[44m[📡 STDOUT] ^[[49m[2753/4732] Building CXX object contrib/client-c/src/CMakeFiles/kv_client.dir/pd/Client.cc.o
    ^[[44m[📡 STDOUT] ^[[49m[2754/4732] Building CXX object contrib/tipb/cpp/CMakeFiles/tipb.dir/tipb/expression.pb.cc.o
    ^[[44m[📡 STDOUT] ^[[49m[2755/4732] Building CXX object contrib/tipb/cpp/CMakeFiles/tipb.dir/tipb/explain.pb.cc.o
    ^[[44m[📡 STDOUT] ^[[49m[2756/4732] Building CXX object contrib/client-c/src/CMakeFiles/kv_client.dir/common/MPPProber.cc.o
    ^[[44m[📡 STDOUT] ^[[49m[2757/4732] Building CXX object contrib/tipb/cpp/CMakeFiles/tipb.dir/tipb/executor.pb.cc.o
    ^[[44m[📡 STDOUT] ^[[49mninja: build stopped: subcommand failed.
    🔓 release the drawin builder....
^[[0
```