### PR TITLE
Add `tryGetBypassLock` and refine `resolveLocks`

### DIFF
--- a/include/pingcap/coprocessor/Client.h
+++ b/include/pingcap/coprocessor/Client.h
@@ -5,7 +5,6 @@
 #include <pingcap/kv/RegionClient.h>
 
 #include <atomic>
-#include <condition_variable>
 #include <cstdint>
 #include <mutex>
 #include <thread>

--- a/include/pingcap/kv/Backoff.h
+++ b/include/pingcap/kv/Backoff.h
@@ -98,6 +98,7 @@ constexpr int prewriteMaxBackoff = 20000;
 constexpr int commitMaxBackoff = 41000;
 constexpr int splitRegionBackoff = 20000;
 constexpr int cleanupMaxBackoff = 20000;
+constexpr int bgResolveLockMaxBackoff = 20000;
 constexpr int copBuildTaskMaxBackoff = 5000;
 constexpr int copNextMaxBackoff = 60000;
 constexpr int pessimisticLockMaxBackoff = 20000;

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -67,6 +67,8 @@ struct Cluster
         mpp_prober->stop();
         if (region_cache)
             region_cache->stop();
+        if (lock_resolver)
+            lock_resolver->stopBgResolve();
         thread_pool->stop();
     }
 

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -223,7 +223,8 @@ public:
 
     int64_t resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed);
 
-    int64_t getBypassLockTs(Backoffer & bo, uint64_t caller_start_ts, const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks, std::vector<uint64_t> & bypass_lock_ts);
+    // tryGetBypassLock checks the status of the transactions which own the locks in `locks`, and collect the txn ids which can be bypassed
+    int64_t tryGetBypassLock(Backoffer & bo, uint64_t caller_start_ts, const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks, std::vector<uint64_t> & bypass_lock_ts);
 
     int64_t resolveLocks(
         Backoffer & bo,

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -11,8 +11,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "kvrpcpb.pb.h"
-
 namespace pingcap
 {
 namespace kv

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -224,7 +224,7 @@ public:
     int64_t resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed);
 
     // tryGetBypassLock checks the status of the transactions which own the locks in `locks`, and collect the txn ids which can be bypassed
-    int64_t tryGetBypassLock(Backoffer & bo, uint64_t caller_start_ts, const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks, std::vector<uint64_t> & bypass_lock_ts);
+    void tryGetBypassLock(Backoffer & bo, uint64_t caller_start_ts, const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks, std::vector<uint64_t> & bypass_lock_ts);
 
     int64_t resolveLocks(
         Backoffer & bo,

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -42,6 +42,12 @@ void Cluster::startBackgroundTasks()
             region_cache->updateCachePeriodically();
         });
     }
+    if (lock_resolver)
+    {
+        thread_pool->enqueue([this] {
+            lock_resolver->backgroundResolve();
+        });
+    }
 }
 
 } // namespace kv


### PR DESCRIPTION
1. add `tryGetBypassLock` which check the txn status, and return the txn that can be bypassed for the caller
2. refine `resolveLocks` to not clear `pushed` even if error happens because each txn is independent with each other, if a txn is `pushed`, its status will not be affected by other txn error
3. add a background thread to resolve locks check by `tryGetBypassLock` asynchronously.