### PR TITLE
proto: use local TiCI proto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,4 +27,45 @@ if (NOT GTEST_FOUND AND ENABLE_TESTS)
 endif()
 
 add_subdirectory (third_party)
+
+set(TICI_PROTO_DIR "${kvClient_SOURCE_DIR}/proto")
+set(TICI_PROTO_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/kvproto")
+file(MAKE_DIRECTORY ${TICI_PROTO_OUTPUT_DIR})
+
+set(TICI_PROTO_DEFS
+    "${TICI_PROTO_DIR}/kvproto/schema.proto"
+    "${TICI_PROTO_DIR}/kvproto/tici.proto"
+)
+set(TICI_PROTO_SRCS
+    "${TICI_PROTO_OUTPUT_DIR}/schema.pb.cc"
+    "${TICI_PROTO_OUTPUT_DIR}/tici.pb.cc"
+    "${TICI_PROTO_OUTPUT_DIR}/tici.grpc.pb.cc"
+)
+set(TICI_PROTO_HDRS
+    "${TICI_PROTO_OUTPUT_DIR}/schema.pb.h"
+    "${TICI_PROTO_OUTPUT_DIR}/tici.pb.h"
+    "${TICI_PROTO_OUTPUT_DIR}/tici.grpc.pb.h"
+)
+
+add_custom_command(
+    OUTPUT ${TICI_PROTO_SRCS} ${TICI_PROTO_HDRS}
+    WORKING_DIRECTORY ${TICI_PROTO_DIR}
+    COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+    ARGS --cpp_out=${CMAKE_CURRENT_BINARY_DIR} -I=${TICI_PROTO_DIR} kvproto/schema.proto kvproto/tici.proto
+    COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+    ARGS --grpc_out=${CMAKE_CURRENT_BINARY_DIR} -I=${TICI_PROTO_DIR} --plugin=protoc-gen-grpc=${gRPC_CPP_PLUGIN} kvproto/tici.proto
+    DEPENDS ${TICI_PROTO_DEFS} ${Protobuf_PROTOC_EXECUTABLE} ${gRPC_CPP_PLUGIN}
+    COMMENT "Generating TiCI C++ proto files"
+    VERBATIM
+)
+
+add_library(tici_proto STATIC ${TICI_PROTO_SRCS} ${TICI_PROTO_HDRS})
+target_include_directories(tici_proto PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${Protobuf_INCLUDE_DIR}
+    ${gRPC_INCLUDE_DIRS}
+)
+target_link_libraries(tici_proto PUBLIC ${Protobuf_LIBRARY} ${gRPC_LIBRARIES} absl::synchronization)
+set(TICI_PROTO_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
 add_subdirectory (src)

--- a/proto/kvproto/schema.proto
+++ b/proto/kvproto/schema.proto
@@ -1,0 +1,133 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package schema;
+
+// ParserType represents the type of parser
+enum ParserType {
+  // Default value must be 0 in proto3
+  UNKNOWN_PARSER = 0;
+  // Default parser
+  DEFAULT_PARSER = 1;
+  // Other parser types
+  OTHER_PARSER = 2;
+}
+
+// ParserInfo represents parser information
+message ParserInfo {
+  // Parser type
+  ParserType parser_type = 1;
+  // Parser parameters
+  map<string, string> parser_params = 2;
+
+  repeated string stop_words = 3;
+}
+
+// TableInfo represents table information
+message TableInfo {
+  uint32 keyspace_id = 1;
+  // Table ID
+  int64 table_id = 2;
+  // Table name
+  string table_name = 3;
+  // Database name
+  string database_name = 4;
+  // Table version
+  int64 version = 5;
+  // Column information
+  repeated ColumnInfo columns = 6;
+  // Whether the table is clustered
+  bool is_clustered = 7;
+  // Whether the table is a partition table
+  bool is_partition = 8;
+  // Logical table ID for partition table, 0 for non-partition tables
+  int64 logical_table_id = 9;
+}
+
+// ColumnInfo represents column information
+message ColumnInfo {
+  // Column ID
+  int64 column_id = 2;
+  // Column name
+  string column_name = 3;
+  // MySQL type
+  int32 type = 4;
+  // Collation
+  string collation = 5;
+  // Column length
+  int32 column_length = 6;
+  // Decimal places
+  int32 decimal = 7;
+  // Flags
+  uint32 flag = 8;
+  // Enum elements
+  repeated string elems = 9;
+  // Default value
+  bytes default_val = 10;
+  // Whether it's a primary key
+  bool is_primary_key = 11;
+  // Whether it's an array
+  bool is_array = 12;
+}
+
+// IndexInfo represents index information
+message IndexInfo {
+  uint32 keyspace_id = 1;
+  // Table ID
+  int64 table_id = 2;
+  // Index ID
+  int64 index_id = 3;
+  // Index name
+  string index_name = 4;
+  // Index type (fulltext, custom)
+  int32 index_type = 5;
+  // Index columns
+  repeated ColumnInfo columns = 6;
+  // Whether the index is unique
+  bool is_unique = 7;
+  // Parser information
+  ParserInfo parser_info = 8;
+  // Other index parameters
+  map<string, string> other_params = 9;
+  // Fulltext index info
+  string fulltext_index = 10;
+  // Hybrid index info
+  string hybrid_index = 11;
+  // PD TSO when the index is created
+  uint64 created_ts = 12;
+}
+
+// PartitionDefinition represents partition table definitions
+message PartitionDefinition {
+  // Partition table ID
+  int64 table_id = 1;
+  // Partition table name
+  string table_name = 2;
+  // Less then value
+  repeated string less_than = 3;
+}
+
+// PartitionTableInfo represents partition table information
+message PartitionTableInfo {
+  // Partition type
+  int32 partition_type = 1;
+  // Partition table expr string
+  string expr = 2;
+  // Partition definitions
+  repeated PartitionDefinition definitions = 3;
+  // Number of partition definitions
+  uint64 num = 4;
+}

--- a/proto/kvproto/tici.proto
+++ b/proto/kvproto/tici.proto
@@ -1,0 +1,330 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package tici;
+
+import "kvproto/schema.proto";
+
+// import "gogoproto/gogo.proto";
+// import "rustproto.proto";
+
+// option (gogoproto.sizer_all) = true;
+// option (gogoproto.marshaler_all) = true;
+// option (gogoproto.unmarshaler_all) = true;
+// option (gogoproto.goproto_unkeyed_all) = false;
+// option (gogoproto.goproto_unrecognized_all) = false;
+// option (gogoproto.goproto_sizecache_all) = false;
+// option (rustproto.lite_runtime_all) = true;
+
+enum ErrorCode {
+  SUCCESS = 0;
+  UNKNOWN_ERROR = 1;
+  INVALID_ARGUMENTS = 2;
+  ERROR_TRY_AGAIN = 3;
+  DEPRECATED = 4;
+  NOT_LEADER = 5;
+
+  SHARD_NOT_FOUND = 11;
+  INDEX_NOT_FOUND = 12;
+  WORKER_NOT_FOUND = 13;
+  SHARD_NOT_SCHEDULED = 14;
+  COMPACTION_NOT_FOUND = 15;
+  FRAG_RANGE_MISMATCH = 16;
+  INVALID_OP = 17;
+  THROTTLED = 18;
+  PROGRESS_UNWINDED = 19;
+}
+
+// Key range definition
+message KeyRange {
+  // Inclusive lower key bound
+  bytes start_key = 1;
+  // Exclusive upper key bound
+  bytes end_key = 2;
+}
+
+// Shard local cache information
+message ShardLocalCacheInfo {
+  ShardManifestHeader shard = 1;
+  repeated string local_cache_addrs = 2;
+}
+
+// Request to get shard local cache information
+message GetShardLocalCacheRequest {
+  // Table ID to filter shards
+  int64 table_id = 1;
+  // Index ID to filter shards
+  int64 index_id = 2;
+  uint32 keyspace_id = 3;
+  repeated KeyRange key_ranges = 4;
+  // at most `limit` shards can be returned
+  int32 limit = 5;
+}
+
+// Response containing shard local cache information
+message GetShardLocalCacheResponse {
+  ErrorCode status = 1;
+  repeated ShardLocalCacheInfo shard_local_cache_infos = 2;
+}
+
+service MetaService {
+  // APIs for create indexes
+
+  // CreateIndex creates a new index
+  rpc CreateIndex(CreateIndexRequest) returns (CreateIndexResponse);
+
+  // DropIndex removes an existing index
+  rpc DropIndex(DropIndexRequest) returns (DropIndexResponse);
+
+  // GetIndexProgress retrieves the current progress of an index build
+  rpc GetIndexProgress(GetIndexProgressRequest)
+      returns (GetIndexProgressResponse);
+
+  // -----------------------------------------------------------------------------
+
+
+  // Get shard local cache information
+  rpc GetShardLocalCacheInfo(GetShardLocalCacheRequest)
+      returns (GetShardLocalCacheResponse);
+
+  // -----------------------------------------------------------------------------
+  // APIs for importing data
+
+  // Get a cloud storage prefix for importing data.
+  // This will create a new import job with a unique job_id and a cloud storage
+  // prefix for the import data. The caller should generate files under the
+  // cloud storage prefix and call `FinishImportPartitionUpload` after uploading
+  // each partition. If there is an existing running import job for the same
+  // identifier, it will return the existing job_id.
+  rpc GetImportStoragePrefix(GetImportStoragePrefixRequest)
+      returns (GetImportStoragePrefixResponse);
+
+  // Called by Import DXF to notify Meta Service after a partition for
+  // the given index are uploaded.
+  rpc FinishImportPartitionUpload(FinishImportPartitionUploadRequest)
+      returns (FinishImportResponse);
+
+  // Called before Add full index build to pre-split shards by
+  // aggregated SortedKV metadata groups.
+  rpc PreSplitImportShards(PreSplitImportShardsRequest)
+      returns (PreSplitImportShardsResponse);
+
+  // Called to notify Meta Service that the whole table/index upload is
+  // finished.
+  rpc FinishImportIndexUpload(FinishImportIndexUploadRequest)
+      returns (FinishImportResponse);
+
+  // -----------------------------------------------------------------------------
+}
+
+message ShardManifestHeader {
+  uint64 shard_id = 1;
+  bytes start_key = 2;
+  bytes end_key = 3;
+  uint64 epoch = 4;
+  uint64 seq = 5;
+}
+
+message S3Location {
+  string bucket = 1;
+  string prefix = 2;
+}
+
+// CreateIndexRequest is a request to create an index
+message CreateIndexRequest {
+  string database_name = 1;
+  bytes table_info = 2;
+  int64 index_id = 3;
+  // Keyspace ID
+  uint32 keyspace_id = 4;
+
+  schema.ParserInfo parser_info = 5;
+}
+
+// CreateIndexResponse is a response to the index creation request
+message CreateIndexResponse {
+  ErrorCode status = 1;
+  // Error message, only valid when status is non-zero
+  string error_message = 2;
+  // Created index ID
+  string index_id = 3;
+}
+
+// DropIndexRequest is a request to drop an index
+message DropIndexRequest {
+  int64 table_id = 1;
+  int64 index_id = 2;
+  // Keyspace ID
+  uint32 keyspace_id = 3;
+}
+
+// DropIndexResponse is a response to the index drop request
+message DropIndexResponse {
+  ErrorCode status = 1;
+  // Error message, only valid when status is non-zero
+  string error_message = 2;
+}
+
+// GetIndexProgressRequest is a request to get the progress of an index build
+message GetIndexProgressRequest {
+  // Table ID
+  int64 table_id = 1;
+  // Index ID
+  int64 index_id = 2;
+  // Keyspace ID
+  uint32 keyspace_id = 3;
+}
+
+// GetIndexProgressResponse only reports coarse-grained build state.
+// Fine-grained import progress is tracked by the DDL layer.
+message GetIndexProgressResponse {
+  enum State {
+    PENDING = 0;
+    RUNNING = 1;
+    COMPLETED = 2;
+    FAILED = 3;
+    NOTFOUND = 4;
+    ERROR = 5;
+  }
+  ErrorCode status = 1;
+  // Error message, only valid when status is non-zero
+  string error_message = 2;
+  // Build task state (PENDING, RUNNING, COMPLETED, FAILED)
+  State state = 3;
+}
+
+// -----------------------------------------------------------------------------
+// TiCI Full-text index data import workflow during Import Into (with DXF):
+// -----------------------------------------------------------------------------
+// 1. TiDB requests a cloud storage object prefix from the TiCI Meta Service.
+//    It provides a unique tidb_task_id that specify a job in the TiDB side. A
+//    job means one Import Into or Index Backfilling operation.
+//
+// 2. Import DXF generate the files for partition data and upload them to the
+//    cloud storage prefix returned by TiCI. The files should contain the
+//    table info, indexes info and the key-value pairs within a specific
+//    key-range.
+//
+// 3. After import DXF has uploaded one partition data belonging to a baseline
+//    full text index, it calls `FinishImportPartitionUpload`. This allows
+//    TiCI to mark the partition as complete and make it available to downstream
+//    consumers.
+//
+// 4. After import DXF has uploaded all partitions data belonging to a baseline
+//    full text index on a job, it calls `FinishImportIndexUpload`.
+//    This allows TiCI to mark the job as complete and make it available to
+//    GC data after consumed by downstream consumers.
+// -----------------------------------------------------------------------------
+
+message GetImportStoragePrefixRequest {
+  // TiDB unique task ID for this Import Into/Index Backfilling job.
+  string tidb_task_id = 1;
+  // Table ID of the target table.
+  int64 table_id = 2;
+  // Index ID of the target index. If this is an Import Into job that relates
+  // to multiple indexes, this field should contain all the index IDs.
+  repeated int64 index_ids = 3;
+  // Keyspace ID
+  uint32 keyspace_id = 4;
+}
+
+message GetImportStoragePrefixResponse {
+  ErrorCode status = 1;
+  // Optional human‑readable diagnostics, only defined when status is not
+  // SUCCESS.
+  string error_message = 2;
+  // The import index job_id in TiCI
+  uint64 job_id = 3;
+  // The cloud storage prefix where the import data should be written.
+  // The format is "s3://bucket/prefix/".
+  string storage_uri = 4;
+}
+
+message FinishImportPartitionUploadRequest {
+  // TiDB unique task ID for this Import Into/Index Backfilling job.
+  string tidb_task_id = 1;
+  // Key range for the partition uploaded.
+  KeyRange key_range = 2;
+  // The cloud storage path where the partition data is written.
+  // The format is "s3://bucket/prefix/filename".
+  string storage_uri = 3;
+  // Keyspace ID
+  uint32 keyspace_id = 4;
+}
+
+// One merged SortedKVMeta group used for import pre-split analysis.
+message PreSplitImportShardMeta {
+  int64 ele_id = 1;
+  bytes start_key = 2;
+  bytes end_key = 3;
+  uint64 total_kv_size = 4;
+  uint64 total_kv_cnt = 5;
+  int32 data_file_count = 6;
+  int32 stat_file_count = 7;
+}
+
+message PreSplitImportShardsRequest {
+  // TiDB unique task ID for this Import Into job.
+  string tidb_task_id = 1;
+  int64 table_id = 2;
+  repeated int64 index_ids = 3;
+  uint64 scan_snapshot_ts = 4;
+  bytes start_key = 5;
+  bytes end_key = 6;
+  uint64 total_kv_size = 7;
+  uint64 total_kv_cnt = 8;
+  int32 data_file_count = 9;
+  int32 stat_file_count = 10;
+  repeated PreSplitImportShardMeta meta_groups = 11;
+  uint32 keyspace_id = 12;
+}
+
+message PreSplitImportIndexResult {
+  int64 table_id = 1;
+  int64 index_id = 2;
+  uint32 split_count = 3;
+  uint32 shard_count_after_split = 4;
+}
+
+message PreSplitImportShardsResponse {
+  ErrorCode status = 1;
+  string error_message = 2;
+  repeated bytes split_keys = 3;
+  repeated PreSplitImportIndexResult index_results = 4;
+}
+
+
+message FinishImportIndexUploadRequest {
+  // TiDB unique task ID for this Import Into/Index Backfilling job.
+  string tidb_task_id = 1;
+  // If status is SUCCESS, the job is finished successfully.
+  // If status is not SUCCESS, the job is aborted or cancelled in TiDB side,
+  // and TiCI should clean up all the related data.
+  ErrorCode status = 2;
+  // The error_message if the status is not SUCCESS.
+  string error_message = 3;
+  // Keyspace ID
+  uint32 keyspace_id = 4;
+}
+
+message FinishImportResponse {
+  ErrorCode status = 1;
+  // Optional human‑readable diagnostics, only defined when status is not
+  // SUCCESS.
+  string error_message = 2;
+}
+
+// -----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,8 +24,9 @@ if (ENABLE_TESTS)
 endif()
 
 add_library(kv_client ${kvClient_sources})
+target_include_directories(kv_client BEFORE PUBLIC ${TICI_PROTO_INCLUDE_DIR})
 target_include_directories(kv_client PUBLIC ${kvClient_INCLUDE_DIR} ${fiu_include_dirs} ${Protobuf_INCLUDE_DIR} ${gRPC_INCLUDE_DIRS})
-target_link_libraries(kv_client kvproto ${Poco_Foundation_LIBRARY} fiu ${Protobuf_LIBRARY} ${gRPC_LIBRARIES})
+target_link_libraries(kv_client kvproto tici_proto ${Poco_Foundation_LIBRARY} fiu ${Protobuf_LIBRARY} ${gRPC_LIBRARIES})
 
 if (ENABLE_TESTS)
     add_subdirectory (test)


### PR DESCRIPTION
1. Switch kvproto from a private, unofficially maintained branch to master. 
2. Temporarily copy the differences(tici.proto, schema.proto) into client-c.