### PR TITLE
ci: add pull build test for release-8.5

### DIFF
--- a/.github/workflows/pull-build-test.yml
+++ b/.github/workflows/pull-build-test.yml
@@ -1,0 +1,42 @@
+name: pull-build-test
+
+on:
+  pull_request:
+    branches:
+      - release-8.5
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Build Builder Image
+        run: docker build -f ci/Dockerfile -t local/tikv-client-c-builder:latest .
+
+      - name: Build And Test
+        run: |
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
+            -v "${GITHUB_WORKSPACE}:/client-c" \
+            -w /client-c \
+            local/tikv-client-c-builder:latest \
+            /bin/bash -c "/client-c/ci/build-test.sh"
+
+      - name: Upload Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: build/**/*.log
+          if-no-files-found: ignore

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,26 +1,54 @@
-FROM ubuntu:23.04
+FROM ubuntu:22.04
 
-RUN apt update -y \
- && apt install -y cmake build-essential \
-        wget git \
-        protobuf-compiler libprotobuf-dev libgrpc-dev libgrpc++-dev libc-ares-dev protobuf-compiler-grpc libpoco-dev
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GOLANG_VERSION=1.13.3
+ARG TARGETARCH
+ARG GO_SHA256_AMD64=0804bf02020dceaa8a7d7275ee79f7a142f1996bfd0c39216ccb405f93f994c0
+ARG GO_SHA256_ARM64=9fa65ae42665baff53802091b49b83af6f2e397986b6cbea2ae30e2c7ee0f2f2
 
-RUN rm -rf /var/lib/apt/lists/*
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-#back to root dir and download golang
-RUN cd / 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        git \
+        protobuf-compiler \
+        libprotobuf-dev \
+        libgrpc-dev \
+        libgrpc++-dev \
+        libc-ares-dev \
+        protobuf-compiler-grpc \
+        libpoco-dev \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.13.3
+RUN case "${TARGETARCH}" in \
+      amd64) GO_ARCH="${TARGETARCH}"; GO_SHA256="${GO_SHA256_AMD64}" ;; \
+      arm64) GO_ARCH="${TARGETARCH}"; GO_SHA256="${GO_SHA256_ARM64}" ;; \
+      "") GO_ARCH="amd64"; GO_SHA256="${GO_SHA256_AMD64}" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && wget -q -O /tmp/go.tgz "https://dl.google.com/go/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz" \
+    && echo "${GO_SHA256}  /tmp/go.tgz" | sha256sum -c - \
+    && tar -C /usr/local -xzf /tmp/go.tgz \
+    && rm -f /tmp/go.tgz
 
-RUN wget -O go.tgz "https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz"; \
-tar -C /usr/local -xzf go.tgz; \
-rm go.tgz; \
-export PATH="/usr/local/go/bin:$PATH"; \
-go version
+ENV GOPATH=/go
+ENV PATH=/usr/local/go/bin:${GOPATH}/bin:${PATH}
+ENV HOME=/home/ciuser
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN groupadd --system ciuser \
+    && useradd --system --create-home --gid ciuser ciuser \
+    && mkdir -p /go /mock-tikv \
+    && chown -R ciuser:ciuser /go /mock-tikv
 
-RUN cd /
+USER ciuser
 
-RUN git clone https://github.com/tikv/mock-tikv.git && cd mock-tikv && git checkout 60d5921028afd72e1aeba880b9052c40e932eef3 && make failpoint-enable && make
+RUN git clone --depth 1 https://github.com/tikv/mock-tikv.git /mock-tikv \
+    && cd /mock-tikv \
+    && git fetch --depth 1 origin 60d5921028afd72e1aeba880b9052c40e932eef3 \
+    && git checkout 60d5921028afd72e1aeba880b9052c40e932eef3 \
+    && make failpoint-enable \
+    && make

--- a/cmake/Modules/FindgRPC.cmake
+++ b/cmake/Modules/FindgRPC.cmake
@@ -268,7 +268,11 @@ else()
     set(gRPC_LIBRARIES ${gRPC_LIBRARIES} ${gRPC_LIBRARY})
   endif()
 endif()
-set(gRPC_LIBRARIES ${gRPC_LIBRARIES} ${gRPC_CARES_LIBRARY} ${gRPC_GPR_LIBRARY} ${gRPC_ADDRESS_SORTING_LIBRARY} ${gRPC_UPB_LIBRARY})
+foreach(_dep IN ITEMS gRPC_CARES_LIBRARY gRPC_GPR_LIBRARY gRPC_ADDRESS_SORTING_LIBRARY gRPC_UPB_LIBRARY)
+  if(${_dep})
+    list(APPEND gRPC_LIBRARIES "${${_dep}}")
+  endif()
+endforeach()
 
 # Restore the original find library ordering.
 if(gRPC_USE_STATIC_LIBS)


### PR DESCRIPTION
ref : https://github.com/tikv/client-c/pull/231
## Summary
- add the pull-build-test GitHub Actions workflow to release-8.5

## Background
PRs targeting release-8.5, such as #237, did not trigger pull-build-test because the workflow only existed on master.
