### PR TITLE
Bypass locks invisible to read snapshot

### DIFF
--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -20,25 +20,20 @@ struct TxnStatus
 {
     uint64_t ttl = 0;
     uint64_t commit_ts = 0;
-    ::kvrpcpb::Action action;
+    ::kvrpcpb::Action action = ::kvrpcpb::Action::NoAction;
     std::optional<::kvrpcpb::LockInfo> primary_lock;
     bool isCommitted() const { return ttl == 0 && commit_ts > 0; }
 
+    bool isRolledBack() const
+    {
+        return ttl == 0 && commit_ts == 0
+            && (action == kvrpcpb::Action::NoAction || action == kvrpcpb::Action::LockNotExistRollback
+                || action == kvrpcpb::Action::TTLExpireRollback);
+    }
+
     bool isCacheable() const
     {
-        if (isCommitted())
-        {
-            return true;
-        }
-        if (ttl == 0)
-        {
-            if (action == kvrpcpb::Action::NoAction || action == kvrpcpb::Action::LockNotExistRollback
-                || action == kvrpcpb::Action::TTLExpireRollback)
-            {
-                return true;
-            }
-        }
-        return false;
+        return isCommitted() || isRolledBack();
     }
 };
 

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -20,8 +20,7 @@ bool canBypassLockForRead(const TxnStatus & status, uint64_t caller_start_ts)
     if (status.primary_lock.has_value() && status.primary_lock->use_async_commit())
         return false;
 
-    // ttl == 0 && commit_ts == 0 means the txn is rolled back / not committed.
-    return status.commit_ts == 0;
+    return status.isRolledBack();
 }
 } // namespace
 

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -6,6 +6,25 @@ namespace pingcap
 {
 namespace kv
 {
+namespace
+{
+bool canBypassLockForRead(const TxnStatus & status, uint64_t caller_start_ts)
+{
+    if (status.ttl != 0)
+        return false;
+
+    if (status.isCommitted())
+        return status.commit_ts > caller_start_ts;
+
+    // Expired async-commit locks need resolveLockAsync to determine the final status.
+    if (status.primary_lock.has_value() && status.primary_lock->use_async_commit())
+        return false;
+
+    // ttl == 0 && commit_ts == 0 means the txn is rolled back / not committed.
+    return status.commit_ts == 0;
+}
+} // namespace
+
 std::string Lock::toDebugString() const
 {
     return "key: " + Redact::keyToDebugString(key) + " primary: " + Redact::keyToDebugString(primary)
@@ -56,6 +75,12 @@ int64_t LockResolver::resolveLocks(
 
             if (status.ttl == 0)
             {
+                if (!for_write && canBypassLockForRead(status, caller_start_ts))
+                {
+                    pushed.push_back(lock->txn_id);
+                    break;
+                }
+
                 bool exists = true;
                 if (clean_txns.find(lock->txn_id) == clean_txns.end())
                 {


### PR DESCRIPTION
### What problem does this PR solve?

For snapshot reads, locks from transactions that are already known to be invisible to the read snapshot do not need to be synchronously resolved before retrying. This includes rolled-back/non-committed transactions and committed transactions whose commit_ts is greater than the read ts.

### What is changed?

- Add a read-path check to bypass locks when the resolved txn status is invisible to the current read snapshot.
- Keep visible committed transactions, commit_ts <= read ts, on the existing resolve-lock path.
- Keep expired async-commit locks on the existing async recovery path until their final status is determined.