### PR TITLE
Add try bypass lock helper

### DIFF
--- a/include/pingcap/kv/Backoff.h
+++ b/include/pingcap/kv/Backoff.h
@@ -100,6 +100,7 @@ constexpr int splitRegionBackoff = 20000;
 constexpr int cleanupMaxBackoff = 20000;
 constexpr int copBuildTaskMaxBackoff = 5000;
 constexpr int copNextMaxBackoff = 60000;
+constexpr int bgResolveLockMaxBackoff = 60000;
 constexpr int pessimisticLockMaxBackoff = 20000;
 
 using BackoffPtr = std::shared_ptr<Backoff>;

--- a/include/pingcap/kv/Backoff.h
+++ b/include/pingcap/kv/Backoff.h
@@ -100,7 +100,7 @@ constexpr int splitRegionBackoff = 20000;
 constexpr int cleanupMaxBackoff = 20000;
 constexpr int copBuildTaskMaxBackoff = 5000;
 constexpr int copNextMaxBackoff = 60000;
-constexpr int bgResolveLockMaxBackoff = 60000;
+constexpr int bgResolveLockMaxBackoff = 5000;
 constexpr int pessimisticLockMaxBackoff = 20000;
 
 using BackoffPtr = std::shared_ptr<Backoff>;

--- a/include/pingcap/kv/Cluster.h
+++ b/include/pingcap/kv/Cluster.h
@@ -48,7 +48,7 @@ struct Cluster
         , oracle(std::make_unique<pd::Oracle>(pd_client, std::chrono::milliseconds(oracle_update_interval)))
         , lock_resolver(std::make_unique<LockResolver>(this))
         , api_version(config.api_version)
-        , thread_pool(std::make_unique<pingcap::common::FixedThreadPool>(2))
+        , thread_pool(std::make_unique<pingcap::common::FixedThreadPool>(3))
         , mpp_prober(std::make_unique<common::MPPProber>(this))
     {
         startBackgroundTasks();
@@ -67,6 +67,8 @@ struct Cluster
         mpp_prober->stop();
         if (region_cache)
             region_cache->stop();
+        if (lock_resolver)
+            lock_resolver->stopBgResolve();
         thread_pool->stop();
     }
 

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -202,6 +202,12 @@ struct AsyncResolveData
 
 using AsyncResolveDataPtr = std::shared_ptr<AsyncResolveData>;
 
+struct TryGetBypassLockResult
+{
+    bool has_pending_resolve = false;
+    bool need_wait_bg_resolve = false;
+};
+
 // LockResolver resolves locks and also caches resolved txn status.
 class LockResolver
 {
@@ -234,8 +240,8 @@ public:
 
     // tryGetBypassLock checks the status of the transactions which own the locks in `locks`, and collect the txn ids which can be bypassed.
     // It is a best-effort optimization and will not synchronously resolve locks in caller's thread.
-    // Returns whether any locks have been scheduled for background resolve.
-    bool tryGetBypassLock(
+    // The result tells the caller whether background resolve is scheduled and whether it is worth waiting for.
+    TryGetBypassLockResult tryGetBypassLock(
         Backoffer & bo,
         uint64_t caller_start_ts,
         const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks,

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -234,7 +234,8 @@ public:
 
     // tryGetBypassLock checks the status of the transactions which own the locks in `locks`, and collect the txn ids which can be bypassed.
     // It is a best-effort optimization and will not synchronously resolve locks in caller's thread.
-    void tryGetBypassLock(
+    // Returns whether any locks have been scheduled for background resolve.
+    bool tryGetBypassLock(
         Backoffer & bo,
         uint64_t caller_start_ts,
         const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks,

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -5,9 +5,17 @@
 #include <pingcap/Log.h>
 #include <pingcap/kv/RegionCache.h>
 
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <queue>
+#include <shared_mutex>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace pingcap
 {
@@ -208,6 +216,10 @@ public:
         cluster = cluster_;
     }
 
+    void backgroundResolve();
+    void addPendingLocksForBgResolve(uint64_t caller_start_ts, const std::vector<LockPtr> & locks);
+    void stopBgResolve();
+
     // resolveLocks tries to resolve Locks. The resolving process is in 3 steps:
     // 1) Use the `lockTTL` to pick up all expired locks. Only locks that are too
     //    old are considered orphan locks and will be handled later. If all locks
@@ -219,6 +231,14 @@ public:
     //    the same transaction.
 
     int64_t resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed);
+
+    // tryGetBypassLock checks the status of the transactions which own the locks in `locks`, and collect the txn ids which can be bypassed.
+    // It is a best-effort optimization and will not synchronously resolve locks in caller's thread.
+    void tryGetBypassLock(
+        Backoffer & bo,
+        uint64_t caller_start_ts,
+        const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks,
+        std::vector<uint64_t> & bypass_lock_ts);
 
     int64_t resolveLocks(
         Backoffer & bo,
@@ -290,6 +310,11 @@ private:
     std::shared_mutex mu;
     std::unordered_map<int64_t, TxnStatus> resolved;
     std::queue<int64_t> cached;
+
+    std::mutex bg_mutex;
+    std::condition_variable bg_cv;
+    std::atomic<bool> stopped{false};
+    std::vector<std::pair<uint64_t, std::vector<LockPtr>>> pending_locks;
 
     Logger * log;
 };

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -257,6 +257,14 @@ public:
     int64_t resolveLocksForWrite(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks);
 
 private:
+    int64_t resolveLocksImpl(
+        Backoffer & bo,
+        uint64_t caller_start_ts,
+        std::vector<LockPtr> & locks,
+        std::vector<uint64_t> & pushed,
+        bool for_write,
+        bool allow_bypass);
+
     void saveResolved(uint64_t txn_id, const TxnStatus & status)
     {
         std::unique_lock<std::shared_mutex> lk(mu);

--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -46,6 +46,7 @@ struct TxnStatus
 };
 
 constexpr size_t resolvedCacheSize = 2048;
+constexpr size_t maxPendingLocksForBgResolve = 4096;
 constexpr int bigTxnThreshold = 16;
 
 const uint64_t defaultLockTTL = 3000;
@@ -223,7 +224,7 @@ public:
     }
 
     void backgroundResolve();
-    void addPendingLocksForBgResolve(uint64_t caller_start_ts, const std::vector<LockPtr> & locks);
+    bool addPendingLocksForBgResolve(uint64_t caller_start_ts, const std::vector<LockPtr> & locks);
     void stopBgResolve();
 
     // resolveLocks tries to resolve Locks. The resolving process is in 3 steps:
@@ -330,6 +331,8 @@ private:
     std::condition_variable bg_cv;
     std::atomic<bool> stopped{false};
     std::vector<std::pair<uint64_t, std::vector<LockPtr>>> pending_locks;
+    size_t pending_lock_count = 0;
+    bool pending_locks_full_logged = false;
 
     Logger * log;
 };

--- a/src/kv/Cluster.cc
+++ b/src/kv/Cluster.cc
@@ -42,6 +42,12 @@ void Cluster::startBackgroundTasks()
             region_cache->updateCachePeriodically();
         });
     }
+    if (lock_resolver)
+    {
+        thread_pool->enqueue([this] {
+            lock_resolver->backgroundResolve();
+        });
+    }
 }
 
 } // namespace kv

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -74,9 +74,9 @@ TryGetBypassLockResult LockResolver::tryGetBypassLock(
                     bypass_lock_ts.push_back(txn_id);
                 }
 
-                if (!is_async_commit && (status.isCommitted() || status.isRolledBack()))
+                if (!is_async_commit && (status.isCommitted() || status.isRolledBack())
+                    && addPendingLocksForBgResolve(caller_start_ts, txn_locks))
                 {
-                    addPendingLocksForBgResolve(caller_start_ts, txn_locks);
                     result.has_pending_resolve = true;
                     if (!can_bypass)
                         result.need_wait_bg_resolve = true;
@@ -149,8 +149,8 @@ int64_t LockResolver::resolveLocksImpl(
                 {
                     pushed.push_back(lock->txn_id);
                     // Let current reads bypass the lock while cleaning it up asynchronously.
-                    addPendingLocksForBgResolve(caller_start_ts, {lock});
-                    break;
+                    if (addPendingLocksForBgResolve(caller_start_ts, {lock}))
+                        break;
                 }
 
                 bool exists = true;
@@ -637,6 +637,8 @@ void LockResolver::backgroundResolve()
             if (stopped.load())
                 return;
             pending_locks.swap(to_resolve);
+            pending_lock_count = 0;
+            pending_locks_full_logged = false;
         }
 
         for (auto & [caller_start_ts, locks] : to_resolve)
@@ -659,11 +661,41 @@ void LockResolver::backgroundResolve()
     }
 }
 
-void LockResolver::addPendingLocksForBgResolve(uint64_t caller_start_ts, const std::vector<LockPtr> & locks)
+bool LockResolver::addPendingLocksForBgResolve(uint64_t caller_start_ts, const std::vector<LockPtr> & locks)
 {
-    std::unique_lock lk(bg_mutex);
-    pending_locks.push_back({caller_start_ts, locks});
-    bg_cv.notify_one();
+    if (locks.empty())
+        return false;
+
+    bool should_log = false;
+    size_t pending_count = 0;
+    {
+        std::unique_lock lk(bg_mutex);
+        if (stopped.load())
+            return false;
+
+        if (locks.size() > maxPendingLocksForBgResolve - pending_lock_count)
+        {
+            should_log = !pending_locks_full_logged;
+            pending_locks_full_logged = true;
+            pending_count = pending_lock_count;
+        }
+        else
+        {
+            pending_locks.push_back({caller_start_ts, locks});
+            pending_lock_count += locks.size();
+            bg_cv.notify_one();
+            return true;
+        }
+    }
+
+    if (should_log)
+    {
+        log->warning(
+            "background resolve lock queue is full, drop pending locks, queue_limit="
+            + std::to_string(maxPendingLocksForBgResolve) + " pending_lock_count=" + std::to_string(pending_count)
+            + " dropped_lock_count=" + std::to_string(locks.size()));
+    }
+    return false;
 }
 
 void LockResolver::stopBgResolve()

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -38,13 +38,13 @@ int64_t LockResolver::resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std
     return resolveLocks(bo, caller_start_ts, locks, pushed, false);
 }
 
-bool LockResolver::tryGetBypassLock(
+TryGetBypassLockResult LockResolver::tryGetBypassLock(
     Backoffer & bo,
     uint64_t caller_start_ts,
     const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks,
     std::vector<uint64_t> & bypass_lock_ts)
 {
-    bool has_pending_resolve = false;
+    TryGetBypassLockResult result;
     try
     {
         bypass_lock_ts.reserve(bypass_lock_ts.size() + locks.size());
@@ -66,7 +66,8 @@ bool LockResolver::tryGetBypassLock(
 
             if (status.ttl == 0)
             {
-                if (canBypassLockForRead(status, caller_start_ts))
+                const bool can_bypass = canBypassLockForRead(status, caller_start_ts);
+                if (can_bypass)
                 {
                     bypass_lock_ts.push_back(txn_id);
                 }
@@ -75,7 +76,9 @@ bool LockResolver::tryGetBypassLock(
                     || (status.primary_lock.has_value() && status.primary_lock->use_async_commit()))
                 {
                     addPendingLocksForBgResolve(caller_start_ts, txn_locks);
-                    has_pending_resolve = true;
+                    result.has_pending_resolve = true;
+                    if (!can_bypass)
+                        result.need_wait_bg_resolve = true;
                 }
             }
             else if (status.action == ::kvrpcpb::MinCommitTSPushed)
@@ -92,7 +95,7 @@ bool LockResolver::tryGetBypassLock(
     {
         log->warning("tryGetBypassLock failed");
     }
-    return has_pending_resolve;
+    return result;
 }
 
 int64_t LockResolver::resolveLocks(

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -35,7 +35,7 @@ std::string Lock::toDebugString() const
 
 int64_t LockResolver::resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed)
 {
-    return resolveLocks(bo, caller_start_ts, locks, pushed, false);
+    return resolveLocksImpl(bo, caller_start_ts, locks, pushed, false, true);
 }
 
 TryGetBypassLockResult LockResolver::tryGetBypassLock(
@@ -105,6 +105,17 @@ int64_t LockResolver::resolveLocks(
     std::vector<uint64_t> & pushed,
     bool for_write)
 {
+    return resolveLocksImpl(bo, caller_start_ts, locks, pushed, for_write, true);
+}
+
+int64_t LockResolver::resolveLocksImpl(
+    Backoffer & bo,
+    uint64_t caller_start_ts,
+    std::vector<LockPtr> & locks,
+    std::vector<uint64_t> & pushed,
+    bool for_write,
+    bool allow_bypass)
+{
     TxnExpireTime before_txn_expired;
     if (locks.empty())
         return before_txn_expired.value();
@@ -133,9 +144,11 @@ int64_t LockResolver::resolveLocks(
 
             if (status.ttl == 0)
             {
-                if (!for_write && canBypassLockForRead(status, caller_start_ts))
+                if (!for_write && allow_bypass && canBypassLockForRead(status, caller_start_ts))
                 {
                     pushed.push_back(lock->txn_id);
+                    // Let current reads bypass the lock while cleaning it up asynchronously.
+                    addPendingLocksForBgResolve(caller_start_ts, {lock});
                     break;
                 }
 
@@ -631,7 +644,7 @@ void LockResolver::backgroundResolve()
             try
             {
                 std::vector<uint64_t> ignored;
-                resolveLocks(bo, caller_start_ts, locks, ignored);
+                resolveLocksImpl(bo, caller_start_ts, locks, ignored, false, false);
             }
             catch (Exception & e)
             {

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -38,12 +38,13 @@ int64_t LockResolver::resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std
     return resolveLocks(bo, caller_start_ts, locks, pushed, false);
 }
 
-void LockResolver::tryGetBypassLock(
+bool LockResolver::tryGetBypassLock(
     Backoffer & bo,
     uint64_t caller_start_ts,
     const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks,
     std::vector<uint64_t> & bypass_lock_ts)
 {
+    bool has_pending_resolve = false;
     try
     {
         bypass_lock_ts.reserve(bypass_lock_ts.size() + locks.size());
@@ -74,6 +75,7 @@ void LockResolver::tryGetBypassLock(
                     || (status.primary_lock.has_value() && status.primary_lock->use_async_commit()))
                 {
                     addPendingLocksForBgResolve(caller_start_ts, txn_locks);
+                    has_pending_resolve = true;
                 }
             }
             else if (status.action == ::kvrpcpb::MinCommitTSPushed)
@@ -90,6 +92,7 @@ void LockResolver::tryGetBypassLock(
     {
         log->warning("tryGetBypassLock failed");
     }
+    return has_pending_resolve;
 }
 
 int64_t LockResolver::resolveLocks(

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -103,7 +103,6 @@ int64_t LockResolver::resolveLocks(
     if (locks.empty())
         return before_txn_expired.value();
     std::unordered_map<uint64_t, std::unordered_set<RegionVerID>> clean_txns;
-    bool push_fail = false;
     if (!for_write)
     {
         pushed.reserve(locks.size());
@@ -123,7 +122,6 @@ int64_t LockResolver::resolveLocks(
             {
                 log->warning("get txn status failed: " + e.displayText());
                 before_txn_expired.update(0);
-                pushed.clear();
                 return before_txn_expired.value();
             }
 
@@ -176,7 +174,6 @@ int64_t LockResolver::resolveLocks(
                 {
                     log->warning("resolve txn failed: " + e.displayText());
                     before_txn_expired.update(0);
-                    pushed.clear();
                     return before_txn_expired.value();
                 }
             }
@@ -193,7 +190,6 @@ int64_t LockResolver::resolveLocks(
                     if (lock->lock_type != ::kvrpcpb::PessimisticLock && lock->txn_id > caller_start_ts)
                     {
                         log->warning("write conflict detected");
-                        pushed.clear();
                         // TODO: throw write conflict exception
                         throw Exception("write conflict", ErrorCodes::UnknownError);
                     }
@@ -202,7 +198,6 @@ int64_t LockResolver::resolveLocks(
                 {
                     if (status.action != ::kvrpcpb::MinCommitTSPushed)
                     {
-                        push_fail = true;
                         break;
                     }
                     pushed.push_back(lock->txn_id);
@@ -210,10 +205,6 @@ int64_t LockResolver::resolveLocks(
             }
             break;
         }
-    }
-    if (push_fail)
-    {
-        pushed.clear();
     }
     return before_txn_expired.value();
 }

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -66,14 +66,15 @@ TryGetBypassLockResult LockResolver::tryGetBypassLock(
 
             if (status.ttl == 0)
             {
+                const bool is_async_commit
+                    = status.primary_lock.has_value() && status.primary_lock->use_async_commit();
                 const bool can_bypass = canBypassLockForRead(status, caller_start_ts);
                 if (can_bypass)
                 {
                     bypass_lock_ts.push_back(txn_id);
                 }
 
-                if (status.isCommitted() || status.isRolledBack()
-                    || (status.primary_lock.has_value() && status.primary_lock->use_async_commit()))
+                if (!is_async_commit && (status.isCommitted() || status.isRolledBack()))
                 {
                     addPendingLocksForBgResolve(caller_start_ts, txn_locks);
                     result.has_pending_resolve = true;

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -664,7 +664,7 @@ void LockResolver::backgroundResolve()
 bool LockResolver::addPendingLocksForBgResolve(uint64_t caller_start_ts, const std::vector<LockPtr> & locks)
 {
     if (locks.empty())
-        return false;
+        return true;
 
     bool should_log = false;
     size_t pending_count = 0;

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -1,4 +1,5 @@
 #include <pingcap/RedactHelpers.h>
+#include <pingcap/kv/Backoff.h>
 #include <pingcap/kv/LockResolver.h>
 #include <pingcap/kv/RegionClient.h>
 
@@ -35,6 +36,60 @@ std::string Lock::toDebugString() const
 int64_t LockResolver::resolveLocks(Backoffer & bo, uint64_t caller_start_ts, std::vector<LockPtr> & locks, std::vector<uint64_t> & pushed)
 {
     return resolveLocks(bo, caller_start_ts, locks, pushed, false);
+}
+
+void LockResolver::tryGetBypassLock(
+    Backoffer & bo,
+    uint64_t caller_start_ts,
+    const std::unordered_map<uint64_t, std::vector<LockPtr>> & locks,
+    std::vector<uint64_t> & bypass_lock_ts)
+{
+    try
+    {
+        bypass_lock_ts.reserve(bypass_lock_ts.size() + locks.size());
+        for (const auto & [txn_id, txn_locks] : locks)
+        {
+            if (txn_locks.empty())
+                continue;
+
+            TxnStatus status;
+            try
+            {
+                status = getTxnStatusFromLock(bo, txn_locks.front(), caller_start_ts, false);
+            }
+            catch (Exception & e)
+            {
+                log->warning("get txn status failed: " + e.displayText());
+                continue;
+            }
+
+            if (status.ttl == 0)
+            {
+                if (canBypassLockForRead(status, caller_start_ts))
+                {
+                    bypass_lock_ts.push_back(txn_id);
+                }
+
+                if (status.isCommitted() || status.isRolledBack()
+                    || (status.primary_lock.has_value() && status.primary_lock->use_async_commit()))
+                {
+                    addPendingLocksForBgResolve(caller_start_ts, txn_locks);
+                }
+            }
+            else if (status.action == ::kvrpcpb::MinCommitTSPushed)
+            {
+                bypass_lock_ts.push_back(txn_id);
+            }
+        }
+    }
+    catch (Exception & e)
+    {
+        log->warning("tryGetBypassLock failed: " + e.displayText());
+    }
+    catch (...)
+    {
+        log->warning("tryGetBypassLock failed");
+    }
 }
 
 int64_t LockResolver::resolveLocks(
@@ -560,6 +615,52 @@ TxnStatus LockResolver::getTxnStatusFromLock(Backoffer & bo, LockPtr lock, uint6
     }
 }
 
+void LockResolver::backgroundResolve()
+{
+    while (!stopped.load())
+    {
+        std::vector<std::pair<uint64_t, std::vector<LockPtr>>> to_resolve;
+        {
+            std::unique_lock lk(bg_mutex);
+            bg_cv.wait(lk, [this] { return !pending_locks.empty() || stopped.load(); });
+            if (stopped.load())
+                return;
+            pending_locks.swap(to_resolve);
+        }
+
+        for (auto & [caller_start_ts, locks] : to_resolve)
+        {
+            pingcap::kv::Backoffer bo(pingcap::kv::bgResolveLockMaxBackoff);
+            try
+            {
+                std::vector<uint64_t> ignored;
+                resolveLocks(bo, caller_start_ts, locks, ignored);
+            }
+            catch (Exception & e)
+            {
+                log->warning("background resolve lock failed: " + e.displayText());
+            }
+            catch (...)
+            {
+                log->warning("background resolve lock failed");
+            }
+        }
+    }
+}
+
+void LockResolver::addPendingLocksForBgResolve(uint64_t caller_start_ts, const std::vector<LockPtr> & locks)
+{
+    std::unique_lock lk(bg_mutex);
+    pending_locks.push_back({caller_start_ts, locks});
+    bg_cv.notify_one();
+}
+
+void LockResolver::stopBgResolve()
+{
+    std::unique_lock lk(bg_mutex);
+    stopped.store(true);
+    bg_cv.notify_all();
+}
 
 } // namespace kv
 } // namespace pingcap


### PR DESCRIPTION
## Summary
- add a helper to check whether read locks can be bypassed
- return whether there are locks pending background resolve
- keep partial pushed lock timestamps when resolving read locks

## Tests
- Not run (PR creation only).