### PR TITLE
Fix dangling TxnStatus pointer in LockResolver

### DIFF
--- a/include/pingcap/kv/LockResolver.h
+++ b/include/pingcap/kv/LockResolver.h
@@ -251,14 +251,14 @@ private:
         }
     }
 
-    TxnStatus * getResolved(uint64_t txn_id)
+    std::optional<TxnStatus> getResolved(uint64_t txn_id)
     {
         std::shared_lock<std::shared_mutex> lk(mu);
 
         auto it = resolved.find(txn_id);
         if (it == resolved.end())
-            return nullptr;
-        return &(it->second);
+            return std::nullopt;
+        return it->second;
     }
 
 

--- a/src/kv/LockResolver.cc
+++ b/src/kv/LockResolver.cc
@@ -147,8 +147,8 @@ int64_t LockResolver::resolveLocksForWrite(Backoffer & bo, uint64_t caller_start
 
 TxnStatus LockResolver::getTxnStatus(Backoffer & bo, uint64_t txn_id, const std::string & primary, uint64_t caller_start_ts, uint64_t current_ts, bool rollback_if_not_exists, bool force_sync_commit, bool is_txn_file)
 {
-    TxnStatus * cached_status = getResolved(txn_id);
-    if (cached_status != nullptr)
+    auto cached_status = getResolved(txn_id);
+    if (cached_status.has_value())
     {
         return *cached_status;
     }


### PR DESCRIPTION
fix #246
Return a copy of the cached TxnStatus to keep it valid after concurrent cache eviction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated lock-resolution cache retrieval to use an “absence vs. present” return pattern, improving reliability when cached transaction information is missing.
  * Ensured cached statuses are returned consistently without relying on null pointer checks.
* **Bug Fixes**
  * Fixed transaction lock-status handling to better reflect resolved-state availability, reducing the risk of incorrect or stale status reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->